### PR TITLE
Auto containers on every site (harden foundation)

### DIFF
--- a/src/containers/auto.ts
+++ b/src/containers/auto.ts
@@ -66,17 +66,20 @@ export class AutoContainer {
     const target = targetFor(details.url);
     if (!target) return {};
 
-    const container = await this.containers.getOrCreate(target.name, target.color);
-
+    // Read the tab BEFORE creating any container, so a navigation whose tab has already gone away
+    // (fast close, prerender discarded) never leaves an orphan container behind in the picker.
     let tab: browser.tabs.Tab;
     try {
       tab = await browser.tabs.get(details.tabId);
     } catch {
       return {}; // tab vanished mid flight
     }
+
+    const container = await this.containers.getOrCreate(target.name, target.color);
     if (tab.cookieStoreId === container.cookieStoreId) return {}; // already in the right container
 
-    // Wrong container: reopen this URL in the correct one, then discard the old tab.
+    // Wrong container: reopen this URL in the correct one, then discard the old tab. The reopened
+    // tab starts in the right container, so its own navigation passes straight through, no loop.
     await browser.tabs.create({
       url: details.url,
       cookieStoreId: container.cookieStoreId,

--- a/src/containers/manager.ts
+++ b/src/containers/manager.ts
@@ -10,8 +10,27 @@ export interface Container {
 }
 
 export class ContainerManager {
+  // In flight resolutions keyed by container name. Two navigations to the same brand new site can
+  // land in getOrCreate at once; without this cache both would query (find nothing) and both would
+  // create, leaving duplicate containers in the Firefox picker. Sharing one promise per name means
+  // the second caller awaits the first caller's create instead of racing it.
+  private readonly inFlight = new Map<string, Promise<Container>>();
+
   /** Return the container named `name`, creating it if it does not yet exist. Idempotent. */
   async getOrCreate(name: string, color?: ContainerColor): Promise<Container> {
+    const pending = this.inFlight.get(name);
+    if (pending) return pending;
+
+    const resolution = this.resolve(name, color);
+    this.inFlight.set(name, resolution);
+    try {
+      return await resolution;
+    } finally {
+      this.inFlight.delete(name);
+    }
+  }
+
+  private async resolve(name: string, color?: ContainerColor): Promise<Container> {
     const existing = await browser.contextualIdentities.query({ name });
     const found = existing[0];
     if (found) {


### PR DESCRIPTION
Closes #3

## Summary

Every site automatically gets its own Firefox container when the extension is enabled, with no manual site list and no user knobs. The foundation (already merged) shipped the core of this: this PR verifies each acceptance criterion against the real code and closes two robustness gaps rather than rewriting working logic.

The core flow: `onBeforeRequest` intercepts every top level (`main_frame`) navigation, computes the container for the URL's registrable domain, and if the tab is in the wrong container it reopens the same URL in the correct one and drops the old tab. The reopened tab already starts in the right container, so its own navigation passes straight through with no loop.

## What the foundation already implemented

* Automatic per site assignment via a single `webRequest` listener, no manual list.
* One container per registrable domain (`registrableDomain` handles multi label public suffixes and raw IPv4), so cookies, logins and storage never cross sites.
* `contextualIdentities.create` registers each container, so it shows up in the Firefox container picker.
* Disabled path: `applyConfig` calls `autoContainer.disable()` to remove the listener, and the handler also short circuits on the config check, so nothing is created and nothing is redirected.
* Non http/https schemes (about:, moz-extension:, file:) and non tab requests (tabId < 0) are ignored.

## What this PR adds

* Race dedupe in `ContainerManager.getOrCreate`: an in flight promise cache keyed by container name. Two concurrent navigations to the same brand new site would previously both query (find nothing) and both create, leaving duplicate containers in the picker. The second caller now awaits the first.
* Orphan prevention in the handler: the tab is read before any container is created, so a navigation whose tab has already gone away (fast close, discarded prerender) never leaves an unused container behind.

## Design choice (kept simple for v0)

Previously auto created containers are left in place rather than cleaned up: they are cheap, reused on the next visit to the same site, and pruning them risks discarding a container a background tab is still using. Documented here so the choice is explicit.

## Acceptance criteria

* [x] When enabled, visiting any site automatically assigns it a dedicated container, with no manual site list. (`onBeforeRequest` reassignment keyed by `targetFor(url)`.)
* [x] Cookies, logins and storage do not cross between sites, one container per registrable domain. (`registrableDomain` plus `getOrCreate` keyed by domain name.)
* [x] Auto created containers appear in the Firefox container picker. (`contextualIdentities.create`.)
* [x] When disabled, no new containers are created and no site is redirected. (Listener removed on disable, plus config short circuit in the handler.)

## Verification

`npm run build` and `npm run lint:ext` are both green: 0 errors, 0 warnings, 0 notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)