### PR TITLE
Per site burner email autofill (v0)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -15,6 +15,7 @@ await build({
     "fingerprint-audio": "src/fingerprint/audio.ts",
     "fingerprint-plugins": "src/fingerprint/plugins.ts",
     "fingerprint-report-relay": "src/fingerprint/report-relay.ts",
+    "email-autofill": "src/email/autofill.ts",
   },
   outdir: "dist",
   bundle: true,

--- a/src/background.ts
+++ b/src/background.ts
@@ -9,6 +9,7 @@ import { AutoContainer } from "./containers/auto";
 import { HeaderUniformizer } from "./fingerprint/headers";
 import { CapturesStore } from "./fingerprint/captures-store";
 import { REPORT_MESSAGE_TYPE, GET_CAPTURES_MESSAGE_TYPE, isCaptureMessage } from "./fingerprint/report";
+import { getBurnerFor } from "./email/store";
 
 // Before and after capture store (ticket #4). Kept in its own module and referenced from a few
 // clearly separated lines so this block merges cleanly with other tickets touching background.ts.
@@ -54,6 +55,25 @@ async function setFingerprint(on: boolean): Promise<void> {
   }
 }
 
+// Burner email autofill (issue #5). Registered only while the extension is enabled, so the disabled
+// path never injects it. The content script asks back for the site's burner address via the
+// "poison:burner" message handled below.
+let burnerHandle: RegisteredScript | null = null;
+
+async function setBurnerAutofill(on: boolean): Promise<void> {
+  if (on && burnerHandle === null) {
+    burnerHandle = await browser.contentScripts.register({
+      matches: ["http://*/*", "https://*/*"],
+      js: [{ file: "dist/email-autofill.js" }],
+      runAt: "document_idle",
+      allFrames: false,
+    });
+  } else if (!on && burnerHandle !== null) {
+    await burnerHandle.unregister();
+    burnerHandle = null;
+  }
+}
+
 /** Apply the current config: wire every protection on when enabled, off when disabled. Idempotent. */
 async function applyConfig(): Promise<void> {
   const config = await loadConfig();
@@ -61,6 +81,7 @@ async function applyConfig(): Promise<void> {
   if (!config.enabled) {
     autoContainer.disable();
     await setFingerprint(false);
+    await setBurnerAutofill(false);
     headers.disable();
     console.info("[poison] disabled, all protections off.");
     return;
@@ -68,8 +89,9 @@ async function applyConfig(): Promise<void> {
 
   autoContainer.enable();
   await setFingerprint(true);
+  await setBurnerAutofill(true);
   headers.enable();
-  console.info("[poison] enabled, auto containers and fingerprint uniformization on.");
+  console.info("[poison] enabled, auto containers, fingerprint uniformization and burner autofill on.");
 }
 
 browser.runtime.onInstalled.addListener(() => void applyConfig());
@@ -80,7 +102,7 @@ void applyConfig();
 
 browser.runtime.onMessage.addListener(
   (message: unknown, sender: browser.runtime.MessageSender): Promise<unknown> | undefined => {
-    const msg = message as { type?: string; tabId?: number };
+    const msg = message as { type?: string; tabId?: number; hostname?: string };
     if (msg?.type === "poison:apply") {
       return applyConfig().then(() => ({ ok: true }));
     }
@@ -96,6 +118,13 @@ browser.runtime.onMessage.addListener(
     if (msg?.type === GET_CAPTURES_MESSAGE_TYPE) {
       const tabId = typeof msg.tabId === "number" ? msg.tabId : sender.tab?.id;
       return Promise.resolve({ captures: typeof tabId === "number" ? captures.get(tabId) : [] });
+    }
+    // The autofill content script asks for the site's burner address. Only answer when enabled and a
+    // hostname was supplied, so nothing is filled while the extension is off.
+    if (msg?.type === "poison:burner" && typeof msg.hostname === "string") {
+      return loadConfig().then((config) =>
+        config.enabled ? getBurnerFor(msg.hostname as string).then((address) => ({ address })) : {},
+      );
     }
     return undefined;
   },

--- a/src/email/autofill.ts
+++ b/src/email/autofill.ts
@@ -1,0 +1,83 @@
+// Content script, registered dynamically when the extension is enabled (see background.ts). It finds
+// signup and email fields on the page and fills each empty one with this site's burner address, so a
+// unique throwaway address is offered per site without the user having to think about it.
+//
+// It runs in the CONTENT world (not the page world) because it manipulates the site's real form
+// controls and asks the background for the site's address. The background gates on the enabled flag
+// and only registers this script when the extension is on, so the disabled path stays clean: when
+// off, this file is never injected.
+//
+// Unobtrusive by design: it fills only fields that are empty, dispatches input and change events so
+// frameworks notice the value, and never overwrites something the user has typed.
+
+/** Ask the background for this site's burner address. */
+async function fetchBurnerAddress(): Promise<string | null> {
+  try {
+    const reply = (await browser.runtime.sendMessage({
+      type: "poison:burner",
+      hostname: location.hostname,
+    })) as { address?: string } | undefined;
+    return reply?.address ?? null;
+  } catch {
+    return null; // background unavailable; leave the page untouched
+  }
+}
+
+/**
+ * Whether an input looks like an email field. Covers the explicit type plus the common name, id, and
+ * autocomplete heuristics sites use for signup and login email boxes.
+ */
+function isEmailField(input: HTMLInputElement): boolean {
+  const type = (input.getAttribute("type") ?? "").toLowerCase();
+  if (type === "email") return true;
+  // Password, checkbox, and similar typed inputs are never email fields.
+  if (type && type !== "text") return false;
+
+  const autocomplete = (input.getAttribute("autocomplete") ?? "").toLowerCase();
+  if (autocomplete === "email") return true;
+
+  const haystack = [
+    input.getAttribute("name"),
+    input.id,
+    input.getAttribute("placeholder"),
+    input.getAttribute("aria-label"),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+
+  return /\be[\s._-]?mail\b|courriel/.test(haystack);
+}
+
+/** Fill an empty email field with the address, notifying any listening framework. */
+function fillField(input: HTMLInputElement, address: string): void {
+  if (input.value.trim() !== "") return; // never clobber what the user typed
+  input.value = address;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function fillAll(address: string): void {
+  const inputs = document.querySelectorAll<HTMLInputElement>("input");
+  for (const input of inputs) {
+    if (isEmailField(input)) fillField(input, address);
+  }
+}
+
+async function run(): Promise<void> {
+  const address = await fetchBurnerAddress();
+  if (!address) return;
+
+  fillAll(address);
+
+  // Signup forms are often rendered after load (single page apps, modals). Watch for new email
+  // fields for a short window and fill them as they appear, then stop to stay light.
+  const observer = new MutationObserver(() => fillAll(address));
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+  window.setTimeout(() => observer.disconnect(), 10000);
+}
+
+void run();
+
+// Keep this file's symbols local (tsc treats content scripts as one global script scope otherwise).
+export {};

--- a/src/email/generator.ts
+++ b/src/email/generator.ts
@@ -1,0 +1,66 @@
+// Burner address generator (v0). Turns a registrable domain into a stable, throwaway email address
+// made of two everyday dictionary words plus an optional number, at a reserved domain that can never
+// resolve. It owns no domain, reaches no real person, and receives nothing.
+//
+// Why ".invalid": RFC 2606 and RFC 6761 reserve the ".invalid" top level domain so that it is
+// permanently guaranteed NOT to resolve in the global DNS. No one can register it, no mail server
+// can exist under it, so a burner address there is inert by construction: no forwarding, no inbox,
+// no cost, no domain ownership required. That is exactly the v0 promise.
+//
+// The two words are common adjectives and nouns only (never a first or last name), so the localpart
+// reads as an anonymous label rather than anything tied to a person. Words are joined with a dot so
+// the value carries no dash character.
+
+/** The reserved, permanently non resolving domain every burner address lives under. */
+export const BURNER_DOMAIN = "example.invalid";
+
+/**
+ * Common adjectives (no person names, no internal hyphens). Chosen for being plainly generic so the
+ * localpart never resembles anyone's identity.
+ */
+const ADJECTIVES: readonly string[] = [
+  "quiet", "amber", "brisk", "clever", "cosmic", "dapper", "eager", "faint", "gentle", "hidden",
+  "jolly", "keen", "lucid", "mellow", "nimble", "plush", "rustic", "silver", "tidy", "velvet",
+  "wandering", "zesty", "bold", "calm", "dusky", "frosty", "golden", "humble", "ivory", "jade",
+  "lively", "misty", "noble", "olive", "polar", "royal", "sable", "teal", "urban", "vivid",
+];
+
+/**
+ * Common nouns (no person names, no internal hyphens). Everyday objects and animals so the pairing
+ * stays anonymous.
+ */
+const NOUNS: readonly string[] = [
+  "otter", "meadow", "lantern", "pebble", "harbor", "willow", "cinder", "maple", "thistle", "cove",
+  "brook", "canyon", "ember", "fjord", "glacier", "hollow", "island", "juniper", "kettle", "lagoon",
+  "marble", "nectar", "orchard", "pixel", "quartz", "ridge", "summit", "timber", "umbra", "valley",
+  "walnut", "yarrow", "zephyr", "acorn", "basalt", "cedar", "dune", "fern", "grove", "heather",
+];
+
+/**
+ * A small, non secret hash (FNV like) over the domain. It only needs to spread inputs across the
+ * word tables deterministically, so a stable 32 bit accumulator is enough.
+ */
+function hashDomain(domain: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < domain.length; i++) {
+    hash ^= domain.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Deterministically derive this site's burner address from its registrable domain. The same domain
+ * always yields the same address; different domains almost always differ (two words plus a number
+ * give tens of thousands of combinations). The result is `word.word[number]@example.invalid`.
+ */
+export function burnerAddressFor(registrableDomain: string): string {
+  const hash = hashDomain(registrableDomain);
+  const adjective = ADJECTIVES[hash % ADJECTIVES.length];
+  const noun = NOUNS[(hash >>> 8) % NOUNS.length];
+  // Optional trailing number widens the space so distinct sites collide far less often. A zero here
+  // means "no number", keeping some addresses as a clean two word pair.
+  const suffix = (hash >>> 16) % 100;
+  const localpart = suffix === 0 ? `${adjective}.${noun}` : `${adjective}.${noun}${suffix}`;
+  return `${localpart}@${BURNER_DOMAIN}`;
+}

--- a/src/email/store.ts
+++ b/src/email/store.ts
@@ -1,0 +1,34 @@
+// Per site burner address store. Keeps the mapping from registrable domain to burner address stable
+// across visits by persisting it in browser.storage.local. The address is derived deterministically
+// from the domain (see generator.ts), so persistence is really a cache: it guarantees the same site
+// keeps the same address even if the word tables ever change, and it makes "same site reuses, other
+// sites differ" trivially true.
+
+import { registrableDomain } from "../containers/auto";
+import { burnerAddressFor } from "./generator";
+
+const STORAGE_KEY = "poisonyourtrace.burners";
+
+type BurnerMap = Record<string, string>;
+
+async function loadMap(): Promise<BurnerMap> {
+  const stored = await browser.storage.local.get(STORAGE_KEY);
+  return (stored[STORAGE_KEY] as BurnerMap | undefined) ?? {};
+}
+
+/**
+ * The burner address for a hostname, keyed by its registrable domain so every subdomain of a site
+ * shares one address. Returns a persisted address when present, otherwise derives one, saves it, and
+ * returns it. Result is stable for a given site across visits.
+ */
+export async function getBurnerFor(hostname: string): Promise<string> {
+  const domain = registrableDomain(hostname);
+  const map = await loadMap();
+  const existing = map[domain];
+  if (existing) return existing;
+
+  const address = burnerAddressFor(domain);
+  map[domain] = address;
+  await browser.storage.local.set({ [STORAGE_KEY]: map });
+  return address;
+}


### PR DESCRIPTION
Closes #5

## Summary

On any page with a signup or email field, this autofills a unique burner address for the current site. The address is two everyday dictionary words plus an optional number, at a reserved domain that can never resolve. It owns no domain, reaches no real person, and receives nothing. This is v0 burner only: no forwarding, no real inbox, no tiers, no options page.

## Example generated address

`amber.island42@example.invalid` (for github.com). Other sites get their own, e.g. `brisk.timber26@example.invalid` for reddit.com. The localpart is a common adjective plus a common noun (never a first or last name), joined with a dot, with an optional trailing number to widen the space.

## Reserved domain choice, and why it never resolves

The domain is `example.invalid`. RFC 2606 and RFC 6761 permanently reserve the `.invalid` top level domain so it is guaranteed NOT to resolve in the global DNS. No one can register it and no mail server can exist under it, so a burner address there is inert by construction: no inbox, no forwarding, no cost, and no domain ownership required. That is exactly the v0 promise.

## How per site reuse works

The address is derived deterministically from the site's registrable domain (a small hash picks two words plus the optional number), then cached in `browser.storage.local` keyed by that registrable domain. So the same site reuses its address across visits and every subdomain shares one address, while different sites get different addresses. The registrable domain logic is imported from the existing auto container helper to avoid duplication.

## Gating

Everything respects the single enabled toggle. The background registers the autofill content script and answers the burner address request only while enabled, so when the extension is off nothing is injected and nothing is filled. The content script fills only empty email fields, dispatches input and change events for frameworks, and never overwrites what the user has typed.

## Files added

- `src/email/generator.ts`, the address generator and bundled wordlist
- `src/email/store.ts`, per domain persistence
- `src/email/autofill.ts`, the content script that finds and fills email fields

`npm run build` and `npm run lint:ext` are both green (zero errors, warnings, notices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)