### PR TITLE
Capture before and after fingerprint values and add a test page (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,38 @@ src/
     webgl.ts           page world override: WebGL vendor and renderer
     audio.ts           page world override: Web Audio readback
     plugins.ts         page world override: navigator plugins and mimeTypes
+    report.ts          the before and after capture contract (shape, message tags)
+    report-relay.ts    isolated world relay: forwards page world captures to the background
+    captures-store.ts  background: per tab before and after snapshot the popup reads
+testpage/
+  fingerprint.html     a standalone page that shows every in scope signal
+  fingerprint-test.js  reads the signals and renders them grouped
 ```
+
+## Before and after captures (for the popup)
+
+Every override, before it replaces a signal, reads the real value the page would have seen and
+posts a `{ signal, group, before, after }` entry out of the page world. The relay forwards these to
+the background, which keeps the latest snapshot per tab. The popup (ticket #6) reads a tab's
+snapshot by sending a runtime message:
+
+```
+browser.runtime.sendMessage({ type: "poison:getCaptures", tabId })
+// resolves to { captures: SignalCapture[] }
+// SignalCapture = { signal, group, before, after }, all strings
+```
+
+Signals with no scalar value (canvas, Web Audio) report `before: "device signature"` and
+`after: "neutralized"`. The snapshot is cleared when the tab navigates or closes. See `report.ts`
+for the full contract.
+
+## Fingerprint test page
+
+Open `testpage/fingerprint.html` directly in Firefox (drag it into a tab, or use a `file://` URL).
+It reads every in scope signal and shows what your browser reports right now. With the extension
+enabled you see the shared common profile (Windows 10 Firefox 128, UTC, en US, a fixed canvas and
+audio hash); with the extension disabled you see your machine's real values. Toggle the extension
+from the toolbar and reload the page to compare the two.
 
 ## Build and run
 

--- a/build.mjs
+++ b/build.mjs
@@ -14,6 +14,7 @@ await build({
     "fingerprint-webgl": "src/fingerprint/webgl.ts",
     "fingerprint-audio": "src/fingerprint/audio.ts",
     "fingerprint-plugins": "src/fingerprint/plugins.ts",
+    "fingerprint-report-relay": "src/fingerprint/report-relay.ts",
   },
   outdir: "dist",
   bundle: true,

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
     "cookies",
     "storage",
     "tabs",
+    "webNavigation",
     "webRequest",
     "webRequestBlocking",
     "<all_urls>"

--- a/src/background.ts
+++ b/src/background.ts
@@ -7,19 +7,30 @@ import { loadConfig } from "./config";
 import { ContainerManager } from "./containers/manager";
 import { AutoContainer } from "./containers/auto";
 import { HeaderUniformizer } from "./fingerprint/headers";
+import { CapturesStore } from "./fingerprint/captures-store";
+import { REPORT_MESSAGE_TYPE, GET_CAPTURES_MESSAGE_TYPE, isCaptureMessage } from "./fingerprint/report";
+
+// Before and after capture store (ticket #4). Kept in its own module and referenced from a few
+// clearly separated lines so this block merges cleanly with other tickets touching background.ts.
+const captures = new CapturesStore();
 
 const containers = new ContainerManager();
 const autoContainer = new AutoContainer(containers);
-const headers = new HeaderUniformizer();
+// The header uniformizer reports the real (before) and applied (after) request header values into
+// the capture store, keyed by the originating tab, so the popup can show the network layer too.
+const headers = new HeaderUniformizer((tabId, entries) => captures.add(tabId, entries));
 
 // The page world scripts that make up fingerprint uniformization. `fingerprint.js` is the base
 // (navigator, screen, timezone, canvas); the others cover WebGL, Web Audio, and plugins/mimeTypes.
-// Each is registered at document_start so it runs before the page's own scripts.
+// `fingerprint-report-relay.js` runs in the isolated world and forwards the page world before and
+// after captures to the background. Each is registered at document_start so it runs before the
+// page's own scripts.
 const FINGERPRINT_SCRIPTS = [
   "dist/fingerprint.js",
   "dist/fingerprint-webgl.js",
   "dist/fingerprint-audio.js",
   "dist/fingerprint-plugins.js",
+  "dist/fingerprint-report-relay.js",
 ];
 
 type RegisteredScript = Awaited<ReturnType<typeof browser.contentScripts.register>>;
@@ -67,10 +78,32 @@ browser.runtime.onStartup.addListener(() => void applyConfig());
 // protections are armed without needing a manual toggle.
 void applyConfig();
 
-browser.runtime.onMessage.addListener((message: unknown): Promise<unknown> | undefined => {
-  const msg = message as { type?: string };
-  if (msg?.type === "poison:apply") {
-    return applyConfig().then(() => ({ ok: true }));
-  }
-  return undefined;
+browser.runtime.onMessage.addListener(
+  (message: unknown, sender: browser.runtime.MessageSender): Promise<unknown> | undefined => {
+    const msg = message as { type?: string; tabId?: number };
+    if (msg?.type === "poison:apply") {
+      return applyConfig().then(() => ({ ok: true }));
+    }
+    // A relay content script forwarding page world before and after captures. Attribute them to the
+    // sender's tab so the popup can read this tab's snapshot.
+    if (isCaptureMessage(message) && msg.type === REPORT_MESSAGE_TYPE) {
+      const tabId = sender.tab?.id;
+      if (typeof tabId === "number") captures.add(tabId, message.captures);
+      return Promise.resolve({ ok: true });
+    }
+    // The popup asks for a tab's before and after snapshot. It may pass an explicit tabId, otherwise
+    // we fall back to the sender's tab. This is the documented read interface ticket #6 consumes.
+    if (msg?.type === GET_CAPTURES_MESSAGE_TYPE) {
+      const tabId = typeof msg.tabId === "number" ? msg.tabId : sender.tab?.id;
+      return Promise.resolve({ captures: typeof tabId === "number" ? captures.get(tabId) : [] });
+    }
+    return undefined;
+  },
+);
+
+// Clear a tab's snapshot when it navigates to a new document or is closed, so the popup never shows
+// stale before and after values from a previous page. The overrides repopulate on the next load.
+browser.webNavigation.onBeforeNavigate.addListener((details) => {
+  if (details.frameId === 0) captures.clear(details.tabId);
 });
+browser.tabs.onRemoved.addListener((tabId) => captures.clear(tabId));

--- a/src/fingerprint/audio.ts
+++ b/src/fingerprint/audio.ts
@@ -15,14 +15,17 @@
 // analyser read APIs, not the audio graph or its output to speakers. Inline injection can also be
 // blocked by a strict page Content Security Policy (same seam as inject.ts).
 
+import { REPORT_MESSAGE_TYPE, OPAQUE_BEFORE, NEUTRALIZED_AFTER } from "./report";
+
 /**
  * Runs in the PAGE world. Must be fully self contained: it is serialized with `toString()` and may
- * reference only its arguments (`fill`) and standard globals, never module scope symbols.
+ * reference only its arguments and standard globals, never module scope symbols. The report tag and
+ * sentinels are passed in so it can post its before and after capture out of the page world.
  *
  * @param fill the single fixed sample value every readback is flattened to (0 means a silent
  *   buffer, so a sum of absolute samples becomes exactly zero).
  */
-function pageWorldOverride(fill: number): void {
+function pageWorldOverride(fill: number, reportType: string, opaqueBefore: string, neutralized: string): void {
   // Replace a prototype method, tolerating a missing or frozen prototype rather than throwing.
   const patch = (proto: object | undefined, name: string, impl: (...args: never[]) => unknown): void => {
     try {
@@ -77,6 +80,17 @@ function pageWorldOverride(fill: number): void {
     // Time domain byte data is centred at 128 (zero amplitude), matching a silent signal.
     if (array && typeof array.length === "number") array.fill(128);
   });
+
+  // Web Audio readback has no scalar value to compare, so we report the agreed sentinels: the real
+  // device rendered signature before, neutralized after. A failure to post must not disturb the page.
+  try {
+    const captures = [
+      { signal: "audio.readback", group: "audio", before: opaqueBefore, after: neutralized },
+    ];
+    window.postMessage({ type: reportType, captures }, "*");
+  } catch {
+    /* postMessage unavailable: drop the batch, the override still applied */
+  }
 }
 
 // Fixed constant shared by every user: a silent buffer. This makes the audio readback value
@@ -84,7 +98,7 @@ function pageWorldOverride(fill: number): void {
 const AUDIO_FILL = 0;
 
 function inject(): void {
-  const code = `(${pageWorldOverride.toString()})(${JSON.stringify(AUDIO_FILL)});`;
+  const code = `(${pageWorldOverride.toString()})(${JSON.stringify(AUDIO_FILL)}, ${JSON.stringify(REPORT_MESSAGE_TYPE)}, ${JSON.stringify(OPAQUE_BEFORE)}, ${JSON.stringify(NEUTRALIZED_AFTER)});`;
   const script = document.createElement("script");
   script.textContent = code;
   const root = document.documentElement ?? document.head ?? document.body;

--- a/src/fingerprint/captures-store.ts
+++ b/src/fingerprint/captures-store.ts
@@ -1,0 +1,43 @@
+// Per tab before and after capture store, owned by the background.
+//
+// The page world overrides (via the report relay) and the header uniformizer both report
+// { signal, group, before, after } entries for the tab they ran in. This store keeps the latest
+// snapshot per tab in memory and answers the popup's read (ticket #6). It is deliberately a plain,
+// self contained object so the background wiring stays a few lines and merges cleanly with other
+// tickets that also touch background.ts.
+//
+// In memory, not persisted: captures describe the LIVE tab and are cheap to regenerate on the next
+// page load. We clear a tab's entry when it navigates or closes so stale values never leak.
+
+import type { SignalCapture } from "./report";
+
+export class CapturesStore {
+  // tabId to a map of signal name to its latest capture. A map keyed by signal name means a repeated
+  // report for the same signal (e.g. many requests rewriting the User Agent header) overwrites
+  // rather than piles up, so each signal appears once.
+  private readonly byTab = new Map<number, Map<string, SignalCapture>>();
+
+  /** Merge a batch of captures into a tab's snapshot, replacing any prior entry per signal. */
+  add(tabId: number, captures: SignalCapture[]): void {
+    if (tabId < 0) return;
+    let signals = this.byTab.get(tabId);
+    if (!signals) {
+      signals = new Map<string, SignalCapture>();
+      this.byTab.set(tabId, signals);
+    }
+    for (const capture of captures) {
+      if (capture && typeof capture.signal === "string") signals.set(capture.signal, capture);
+    }
+  }
+
+  /** The tab's current before and after snapshot as a flat list, or an empty list if none. */
+  get(tabId: number): SignalCapture[] {
+    const signals = this.byTab.get(tabId);
+    return signals ? [...signals.values()] : [];
+  }
+
+  /** Drop a tab's snapshot (on navigation or tab close) so stale before and after values never leak. */
+  clear(tabId: number): void {
+    this.byTab.delete(tabId);
+  }
+}

--- a/src/fingerprint/headers.ts
+++ b/src/fingerprint/headers.ts
@@ -5,20 +5,40 @@
 // User Agent and Accept Language request headers via webRequest.
 
 import { COMMON_PROFILE, acceptLanguageHeader } from "./profile";
+import type { SignalCapture } from "./report";
 
 type BlockingResponse = browser.webRequest.BlockingResponse;
 type Details = browser.webRequest._OnBeforeSendHeadersDetails;
 
+/** Notified with the real (before) and applied (after) request header values, keyed by tab. */
+export type HeaderCaptureSink = (tabId: number, captures: SignalCapture[]) => void;
+
 export class HeaderUniformizer {
   private listening = false;
+
+  /** Optional consumer for the before and after header captures (the background per tab store). */
+  constructor(private readonly onCapture?: HeaderCaptureSink) {}
 
   private readonly handler = (details: Details): BlockingResponse => {
     const headers = details.requestHeaders;
     if (!headers) return {};
+    const applied = acceptLanguageHeader();
+    const captures: SignalCapture[] = [];
     for (const header of headers) {
       const name = header.name.toLowerCase();
-      if (name === "user-agent") header.value = COMMON_PROFILE.ua;
-      else if (name === "accept-language") header.value = acceptLanguageHeader();
+      if (name === "user-agent") {
+        captures.push({ signal: "header.userAgent", group: "headers", before: header.value ?? "", after: COMMON_PROFILE.ua });
+        header.value = COMMON_PROFILE.ua;
+      } else if (name === "accept-language") {
+        captures.push({ signal: "header.acceptLanguage", group: "headers", before: header.value ?? "", after: applied });
+        header.value = applied;
+      }
+    }
+    // Report the header before and after against the originating tab so the popup can show the
+    // network layer alongside the JavaScript layer. tabId is negative for non tab requests; skip
+    // those since the popup asks per tab.
+    if (this.onCapture && typeof details.tabId === "number" && details.tabId >= 0 && captures.length > 0) {
+      this.onCapture(details.tabId, captures);
     }
     return { requestHeaders: headers };
   };

--- a/src/fingerprint/inject.ts
+++ b/src/fingerprint/inject.ts
@@ -11,12 +11,30 @@
 // exportFunction route is the CSP proof hardening left for a later pass.
 
 import { COMMON_PROFILE, type CommonProfile } from "./profile";
+import { REPORT_MESSAGE_TYPE, OPAQUE_BEFORE, NEUTRALIZED_AFTER } from "./report";
 
 /**
  * Runs in the PAGE world. Must be fully self contained: it is serialized with `toString()` and may
- * reference only its argument (`p`) and standard globals, never module scope symbols.
+ * reference only its arguments and standard globals, never module scope symbols. The report tag and
+ * sentinels are passed in as arguments so it can post its before and after captures out of the page
+ * world without importing anything.
  */
-function pageWorldOverride(p: CommonProfile): void {
+function pageWorldOverride(p: CommonProfile, reportType: string, opaqueBefore: string, neutralized: string): void {
+  // Collected before and after pairs, posted to the isolated world relay at the end of the run.
+  const captures: { signal: string; group: string; before: string; after: string }[] = [];
+  const toStr = (v: unknown): string => {
+    try {
+      if (Array.isArray(v)) return v.join(", ");
+      return String(v);
+    } catch {
+      return "";
+    }
+  };
+  // Record the real value (read BEFORE we replace it) against the value we are about to apply.
+  const record = (signal: string, group: string, before: unknown, after: unknown): void => {
+    captures.push({ signal, group, before: toStr(before), after: toStr(after) });
+  };
+
   const define = (obj: object, prop: string, value: unknown): void => {
     try {
       Object.defineProperty(obj, prop, { get: () => value, configurable: true, enumerable: true });
@@ -24,27 +42,50 @@ function pageWorldOverride(p: CommonProfile): void {
       /* some engines mark a prop non configurable; skip rather than throw into the page */
     }
   };
+  // Capture the real value first, then define the override, so `before` is never the overridden one.
+  const defineAndRecord = (obj: object, prop: string, value: unknown, group: string): void => {
+    let before: unknown = "";
+    try {
+      before = (obj as Record<string, unknown>)[prop];
+    } catch {
+      /* reading the original threw: leave before empty rather than fail the whole override */
+    }
+    record(`${group}.${prop}`, group, before, value);
+    define(obj, prop, value);
+  };
 
   // navigator
-  define(navigator, "userAgent", p.ua);
-  define(navigator, "appVersion", p.ua.replace("Mozilla/", ""));
-  define(navigator, "platform", p.platform);
-  define(navigator, "language", p.language);
-  define(navigator, "languages", Object.freeze([...p.languages]));
-  define(navigator, "hardwareConcurrency", p.hardwareConcurrency);
-  define(navigator, "oscpu", p.platform === "Win32" ? "Windows NT 10.0; Win64; x64" : p.platform);
+  const appVersion = p.ua.replace("Mozilla/", "");
+  const oscpu = p.platform === "Win32" ? "Windows NT 10.0; Win64; x64" : p.platform;
+  defineAndRecord(navigator, "userAgent", p.ua, "navigator");
+  defineAndRecord(navigator, "appVersion", appVersion, "navigator");
+  defineAndRecord(navigator, "platform", p.platform, "navigator");
+  defineAndRecord(navigator, "language", p.language, "navigator");
+  defineAndRecord(navigator, "languages", Object.freeze([...p.languages]), "navigator");
+  defineAndRecord(navigator, "hardwareConcurrency", p.hardwareConcurrency, "navigator");
+  defineAndRecord(navigator, "oscpu", oscpu, "navigator");
 
   // screen and window
-  define(screen, "width", p.screen.width);
-  define(screen, "height", p.screen.height);
-  define(screen, "availWidth", p.screen.availWidth);
-  define(screen, "availHeight", p.screen.availHeight);
-  define(screen, "colorDepth", p.colorDepth);
-  define(screen, "pixelDepth", p.colorDepth);
-  define(window, "devicePixelRatio", p.devicePixelRatio);
+  defineAndRecord(screen, "width", p.screen.width, "screen");
+  defineAndRecord(screen, "height", p.screen.height, "screen");
+  defineAndRecord(screen, "availWidth", p.screen.availWidth, "screen");
+  defineAndRecord(screen, "availHeight", p.screen.availHeight, "screen");
+  defineAndRecord(screen, "colorDepth", p.colorDepth, "screen");
+  defineAndRecord(screen, "pixelDepth", p.colorDepth, "screen");
+  defineAndRecord(window, "devicePixelRatio", p.devicePixelRatio, "screen");
 
   // timezone: Intl.resolvedOptions().timeZone (the common probe) and Date.getTimezoneOffset must agree
   try {
+    let beforeZone = "";
+    let beforeOffset: unknown = "";
+    try {
+      beforeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+      beforeOffset = new Date().getTimezoneOffset();
+    } catch {
+      /* reading the real timezone threw: leave before empty */
+    }
+    record("timezone.zone", "timezone", beforeZone, p.timezone);
+    record("timezone.offsetMinutes", "timezone", beforeOffset, p.timezoneOffsetMinutes);
     const origResolved = Intl.DateTimeFormat.prototype.resolvedOptions;
     Intl.DateTimeFormat.prototype.resolvedOptions = function resolvedOptions() {
       const opts = origResolved.call(this);
@@ -93,13 +134,24 @@ function pageWorldOverride(p: CommonProfile): void {
     ctxProto.getImageData = function getImageData(_x, _y, w, h) {
       return new ImageData(Math.max(1, w | 0), Math.max(1, h | 0));
     };
+    // Canvas readback has no scalar value to compare, so we report the agreed sentinels: the real
+    // device drawn signature before, neutralized after.
+    record("canvas.readback", "canvas", opaqueBefore, neutralized);
   } catch {
     /* canvas API missing (e.g. worker), nothing to uniformize */
+  }
+
+  // Post the collected before and after pairs to the isolated world relay. This is a read out for
+  // the popup, never a protection, so a failure here must not disturb the page.
+  try {
+    window.postMessage({ type: reportType, captures }, "*");
+  } catch {
+    /* postMessage unavailable or serialization failed: drop the batch, overrides still applied */
   }
 }
 
 function inject(): void {
-  const code = `(${pageWorldOverride.toString()})(${JSON.stringify(COMMON_PROFILE)});`;
+  const code = `(${pageWorldOverride.toString()})(${JSON.stringify(COMMON_PROFILE)}, ${JSON.stringify(REPORT_MESSAGE_TYPE)}, ${JSON.stringify(OPAQUE_BEFORE)}, ${JSON.stringify(NEUTRALIZED_AFTER)});`;
   const script = document.createElement("script");
   script.textContent = code;
   const root = document.documentElement ?? document.head ?? document.body;

--- a/src/fingerprint/plugins.ts
+++ b/src/fingerprint/plugins.ts
@@ -13,6 +13,8 @@
 // Policy. The Firefox privileged wrappedJSObject and exportFunction route is the CSP proof
 // hardening left for a later pass.
 
+import { REPORT_MESSAGE_TYPE } from "./report";
+
 /**
  * The five standardized PDF plugin names modern Firefox 128 and Chromium report, in canonical
  * order.
@@ -33,11 +35,13 @@ const PLUGIN_MIME_TYPES: readonly { type: string; suffixes: string; description:
 
 /**
  * Runs in the PAGE world. Must be fully self contained: it is serialized with `toString()` and may
- * reference only its arguments and standard globals, never module scope symbols.
+ * reference only its arguments and standard globals, never module scope symbols. The report tag is
+ * passed in so it can post its before and after captures out of the page world without importing.
  */
 function pageWorldOverride(
   names: readonly string[],
   mimes: readonly { type: string; suffixes: string; description: string }[],
+  reportType: string,
 ): void {
   const define = (obj: object, prop: string, value: unknown): void => {
     try {
@@ -46,6 +50,40 @@ function pageWorldOverride(
       /* some engines mark a prop non configurable; skip rather than throw into the page */
     }
   };
+
+  // Read the REAL plugin and mimeType lists first, before the override, as comma joined names so the
+  // popup can show what the page would have seen. Reading a live PluginArray is index based.
+  const captures: { signal: string; group: string; before: string; after: string }[] = [];
+  const listNames = (arr: { length?: number; item?: (i: number) => { name?: string } | null } | undefined): string => {
+    const out: string[] = [];
+    try {
+      const len = arr && typeof arr.length === "number" ? arr.length : 0;
+      for (let i = 0; i < len; i++) {
+        const entry = arr && arr.item ? arr.item(i) : undefined;
+        if (entry && typeof entry.name === "string") out.push(entry.name);
+      }
+    } catch {
+      /* reading the live list threw: return what we gathered so far */
+    }
+    return out.join(", ");
+  };
+  const listTypes = (arr: { length?: number; item?: (i: number) => { type?: string } | null } | undefined): string => {
+    const out: string[] = [];
+    try {
+      const len = arr && typeof arr.length === "number" ? arr.length : 0;
+      for (let i = 0; i < len; i++) {
+        const entry = arr && arr.item ? arr.item(i) : undefined;
+        if (entry && typeof entry.type === "string") out.push(entry.type);
+      }
+    } catch {
+      /* reading the live list threw: return what we gathered so far */
+    }
+    return out.join(", ");
+  };
+  const beforePlugins = listNames(navigator.plugins as unknown as { length?: number; item?: (i: number) => { name?: string } | null });
+  const beforeMimes = listTypes(navigator.mimeTypes as unknown as { length?: number; item?: (i: number) => { type?: string } | null });
+  captures.push({ signal: "navigator.plugins", group: "plugins", before: beforePlugins, after: names.join(", ") });
+  captures.push({ signal: "navigator.mimeTypes", group: "plugins", before: beforeMimes, after: mimes.map((m) => m.type).join(", ") });
 
   try {
     // A shared, plausible MimeType like object per advertised type. `enabledPlugin` is wired to the
@@ -107,10 +145,18 @@ function pageWorldOverride(
   } catch {
     /* leave navigator untouched if the engine rejects the patch */
   }
+
+  // Post the before and after pairs to the isolated world relay. A failure here must not disturb
+  // the page: capture is a read out for the popup, never a protection.
+  try {
+    window.postMessage({ type: reportType, captures }, "*");
+  } catch {
+    /* postMessage unavailable: drop the batch, the override still applied */
+  }
 }
 
 function inject(): void {
-  const code = `(${pageWorldOverride.toString()})(${JSON.stringify(PLUGIN_NAMES)}, ${JSON.stringify(PLUGIN_MIME_TYPES)});`;
+  const code = `(${pageWorldOverride.toString()})(${JSON.stringify(PLUGIN_NAMES)}, ${JSON.stringify(PLUGIN_MIME_TYPES)}, ${JSON.stringify(REPORT_MESSAGE_TYPE)});`;
   const script = document.createElement("script");
   script.textContent = code;
   const root = document.documentElement ?? document.head ?? document.body;

--- a/src/fingerprint/report-relay.ts
+++ b/src/fingerprint/report-relay.ts
@@ -1,0 +1,32 @@
+// Content script relay, registered dynamically at document_start alongside the fingerprint
+// overrides when the extension is enabled.
+//
+// The overrides run in the PAGE world and cannot talk to the extension directly. They post their
+// before and after captures with window.postMessage. This relay runs in the ISOLATED content world
+// (which the page cannot see) and forwards those captures to the background, which stores them per
+// tab for the popup (ticket #6). The relay is the trust boundary: it accepts only same window
+// messages that match the capture contract and passes nothing else through.
+
+import { REPORT_MESSAGE_TYPE, isCaptureMessage } from "./report";
+
+window.addEventListener("message", (event: MessageEvent) => {
+  // Only accept messages posted from this same window (the injected page script), never from
+  // embedded frames or other origins, and only the capture envelope shape.
+  if (event.source !== window) return;
+  const data = event.data as { type?: unknown };
+  if (data?.type !== REPORT_MESSAGE_TYPE) return;
+  if (!isCaptureMessage(event.data)) return;
+
+  // Forward to the background. It keys the captures by the sender tab, so the popup can ask for the
+  // active tab's before and after view. Errors here are non fatal: capture is a read out for the
+  // popup, never a protection, so a delivery failure must not disturb the page.
+  void browser.runtime
+    .sendMessage({ type: REPORT_MESSAGE_TYPE, captures: event.data.captures })
+    .catch(() => {
+      /* background not ready or tab closing: drop this batch, protection is unaffected */
+    });
+});
+
+// Module scope (no runtime export): keeps this file local so it does not collide with the sibling
+// fingerprint content scripts in tsc's global script scope.
+export {};

--- a/src/fingerprint/report.ts
+++ b/src/fingerprint/report.ts
@@ -1,0 +1,53 @@
+// Before and after capture: the shared data contract between the page world overrides, the content
+// script relay, the background store, and the popup (ticket #6).
+//
+// Each fingerprint override, before it replaces a signal, reads the REAL value the page would have
+// seen. It then posts a list of { signal, before, after } entries out of the page world with
+// window.postMessage. A tiny relay content script (report-relay.ts) forwards those to the
+// background, which keeps them per tab so the popup can answer "what did this tab's fingerprint look
+// like before versus after".
+//
+// Design constraint: the override functions are serialized with toString() and injected into the
+// page world, so they cannot import from this module. They inline their own posting primitive. This
+// module owns the CONTRACT (the message tag, the entry shape, the signal names) so every producer
+// and consumer agrees on one vocabulary.
+
+/** The postMessage tag that marks a before and after report coming out of the page world. */
+export const REPORT_MESSAGE_TYPE = "poison:capture";
+
+/** The runtime message the popup sends to the background to read a tab's captures. */
+export const GET_CAPTURES_MESSAGE_TYPE = "poison:getCaptures";
+
+/**
+ * One captured signal. `before` is the real value the page would have seen with the extension off,
+ * `after` is the uniformized value it now sees. Both are stringified for a stable, popup ready shape.
+ * Signals with no scalar value (canvas, Web Audio) use the sentinels below.
+ */
+export interface SignalCapture {
+  /** Stable identifier for the signal, e.g. "navigator.userAgent" or "canvas.readback". */
+  signal: string;
+  /** Human readable group the popup can use to lay out related rows, e.g. "navigator". */
+  group: string;
+  /** The real value with protection off. */
+  before: string;
+  /** The uniformized value with protection on. */
+  after: string;
+}
+
+/** The envelope a page world override posts with window.postMessage. */
+export interface CaptureMessage {
+  type: typeof REPORT_MESSAGE_TYPE;
+  captures: SignalCapture[];
+}
+
+/** Sentinel `before` value for signals with no readable scalar (canvas, Web Audio). */
+export const OPAQUE_BEFORE = "device signature";
+/** Sentinel `after` value for those same signals once neutralized. */
+export const NEUTRALIZED_AFTER = "neutralized";
+
+/** Type guard the relay uses to accept only well formed capture envelopes from the page. */
+export function isCaptureMessage(value: unknown): value is CaptureMessage {
+  if (typeof value !== "object" || value === null) return false;
+  const msg = value as { type?: unknown; captures?: unknown };
+  return msg.type === REPORT_MESSAGE_TYPE && Array.isArray(msg.captures);
+}

--- a/src/fingerprint/webgl.ts
+++ b/src/fingerprint/webgl.ts
@@ -20,15 +20,18 @@
 // would be a "Firefox that answers like Chrome" contradiction that ADDS entropy. So we split the
 // two: masked returns Firefox's constant "Mozilla", unmasked returns the common ANGLE identity.
 // Intel UHD Graphics 620 is one of the most common integrated GPUs, maximizing the anonymity set.
+import { REPORT_MESSAGE_TYPE } from "./report";
+
 const WEBGL_MASKED = "Mozilla";
 const WEBGL_UNMASKED_VENDOR = "Google Inc. (Intel)";
 const WEBGL_UNMASKED_RENDERER = "ANGLE (Intel, Intel(R) UHD Graphics 620 Direct3D11 vs_5_0 ps_5_0, D3D11)";
 
 /**
  * Runs in the PAGE world. Must be fully self contained: it is serialized with `toString()` and may
- * reference only its arguments and standard globals, never module scope symbols.
+ * reference only its arguments and standard globals, never module scope symbols. The report tag is
+ * passed in so it can post its before and after captures out of the page world without importing.
  */
-function pageWorldOverride(masked: string, unmaskedVendor: string, unmaskedRenderer: string): void {
+function pageWorldOverride(masked: string, unmaskedVendor: string, unmaskedRenderer: string, reportType: string): void {
   // Numeric enum values for the intercepted parameters. These are fixed by the WebGL and extension
   // specs, so hard coding them avoids depending on a live context: VENDOR and RENDERER are core GL
   // enums; the UNMASKED_* pair comes from WEBGL_debug_renderer_info.
@@ -36,6 +39,38 @@ function pageWorldOverride(masked: string, unmaskedVendor: string, unmaskedRende
   const RENDERER = 0x1f01;
   const UNMASKED_VENDOR_WEBGL = 0x9245;
   const UNMASKED_RENDERER_WEBGL = 0x9246;
+
+  // Read the REAL vendor and renderer once, before the override is installed, so the popup can show
+  // the true GPU identity the page would have seen. We probe a live context off screen and query
+  // the same four params we are about to uniformize. This runs on the untouched originals.
+  const captures: { signal: string; group: string; before: string; after: string }[] = [];
+  const readReal = (): { vendor: string; renderer: string; unmaskedVendor: string; unmaskedRenderer: string } => {
+    const real = { vendor: "", renderer: "", unmaskedVendor: "", unmaskedRenderer: "" };
+    try {
+      const canvas = document.createElement("canvas");
+      const gl = (canvas.getContext("webgl") ?? canvas.getContext("experimental-webgl")) as {
+        getParameter: (p: number) => unknown;
+        getExtension: (n: string) => { UNMASKED_VENDOR_WEBGL: number; UNMASKED_RENDERER_WEBGL: number } | null;
+      } | null;
+      if (gl) {
+        real.vendor = String(gl.getParameter(VENDOR));
+        real.renderer = String(gl.getParameter(RENDERER));
+        const dbg = gl.getExtension("WEBGL_debug_renderer_info");
+        if (dbg) {
+          real.unmaskedVendor = String(gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL));
+          real.unmaskedRenderer = String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL));
+        }
+      }
+    } catch {
+      /* no WebGL on this engine, or context creation blocked: leave the reals empty */
+    }
+    return real;
+  };
+  const real = readReal();
+  captures.push({ signal: "webgl.vendor", group: "webgl", before: real.vendor, after: masked });
+  captures.push({ signal: "webgl.renderer", group: "webgl", before: real.renderer, after: masked });
+  captures.push({ signal: "webgl.unmaskedVendor", group: "webgl", before: real.unmaskedVendor, after: unmaskedVendor });
+  captures.push({ signal: "webgl.unmaskedRenderer", group: "webgl", before: real.unmaskedRenderer, after: unmaskedRenderer });
 
   // Wrap one prototype's getParameter: the masked core VENDOR and RENDERER return Firefox's
   // constant "Mozilla" (what a real Firefox reports), while the debug renderer UNMASKED_* params
@@ -66,10 +101,18 @@ function pageWorldOverride(masked: string, unmaskedVendor: string, unmaskedRende
   };
   if (g.WebGLRenderingContext) patch(g.WebGLRenderingContext.prototype);
   if (g.WebGL2RenderingContext) patch(g.WebGL2RenderingContext.prototype);
+
+  // Post the before and after pairs to the isolated world relay. A failure here must not disturb
+  // the page: capture is a read out for the popup, never a protection.
+  try {
+    window.postMessage({ type: reportType, captures }, "*");
+  } catch {
+    /* postMessage unavailable: drop the batch, the override still applied */
+  }
 }
 
 function inject(): void {
-  const code = `(${pageWorldOverride.toString()})(${JSON.stringify(WEBGL_MASKED)}, ${JSON.stringify(WEBGL_UNMASKED_VENDOR)}, ${JSON.stringify(WEBGL_UNMASKED_RENDERER)});`;
+  const code = `(${pageWorldOverride.toString()})(${JSON.stringify(WEBGL_MASKED)}, ${JSON.stringify(WEBGL_UNMASKED_VENDOR)}, ${JSON.stringify(WEBGL_UNMASKED_RENDERER)}, ${JSON.stringify(REPORT_MESSAGE_TYPE)});`;
   const script = document.createElement("script");
   script.textContent = code;
   const root = document.documentElement ?? document.head ?? document.body;

--- a/testpage/fingerprint-test.js
+++ b/testpage/fingerprint-test.js
@@ -1,0 +1,198 @@
+// Self contained fingerprint reader for the Poison your Trace test page.
+//
+// It probes every signal in scope and renders a grouped table. Open this page with the extension
+// enabled to see the shared common profile, and with the extension disabled to see your machine's
+// real values. No build step: it is a plain classic script loaded by fingerprint.html.
+
+(function () {
+  "use strict";
+
+  // A tiny stable hash so a canvas or audio readback becomes one short comparable string. It is a
+  // display convenience, not a security primitive. Identical input bytes give an identical hash, so
+  // a uniformized readback shows the same hash on every machine.
+  function hash(bytes) {
+    var h = 0x811c9dc5;
+    for (var i = 0; i < bytes.length; i++) {
+      h ^= bytes[i];
+      h = (h * 0x01000193) >>> 0;
+    }
+    return ("00000000" + h.toString(16)).slice(-8);
+  }
+
+  function safe(fn) {
+    try {
+      return fn();
+    } catch (err) {
+      return "unavailable (" + (err && err.message ? err.message : String(err)) + ")";
+    }
+  }
+
+  // Draw a small mixed scene, then hash the PNG bytes. Uniformized, the readback is a blank canvas
+  // of the same size, so this hash is identical for every user; real, it encodes the device.
+  function canvasHash() {
+    return safe(function () {
+      var canvas = document.createElement("canvas");
+      canvas.width = 220;
+      canvas.height = 40;
+      var ctx = canvas.getContext("2d");
+      ctx.textBaseline = "top";
+      ctx.font = "16px system-ui";
+      ctx.fillStyle = "#f60";
+      ctx.fillRect(2, 2, 120, 22);
+      ctx.fillStyle = "#069";
+      ctx.fillText("Poison your Trace \u{1F489}", 4, 4);
+      var url = canvas.toDataURL();
+      var comma = url.indexOf(",");
+      var b64 = comma >= 0 ? url.slice(comma + 1) : url;
+      var raw = atob(b64);
+      var bytes = new Uint8Array(raw.length);
+      for (var i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+      return hash(bytes) + " (" + bytes.length + " bytes)";
+    });
+  }
+
+  function webgl() {
+    return safe(function () {
+      var canvas = document.createElement("canvas");
+      var gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+      if (!gl) return { vendor: "no WebGL", renderer: "no WebGL", unmaskedVendor: "", unmaskedRenderer: "" };
+      var out = {
+        vendor: String(gl.getParameter(gl.VENDOR)),
+        renderer: String(gl.getParameter(gl.RENDERER)),
+        unmaskedVendor: "",
+        unmaskedRenderer: "",
+      };
+      var dbg = gl.getExtension("WEBGL_debug_renderer_info");
+      if (dbg) {
+        out.unmaskedVendor = String(gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL));
+        out.unmaskedRenderer = String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL));
+      }
+      return out;
+    });
+  }
+
+  // Render a short oscillator through a compressor offline, then hash a slice of the PCM. Uniformized
+  // the samples are a fixed constant so the hash is identical for every user; real it encodes the
+  // device audio stack.
+  function audioHash() {
+    return new Promise(function (resolve) {
+      try {
+        var Ctx = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+        if (!Ctx) return resolve("no OfflineAudioContext");
+        var ctx = new Ctx(1, 44100, 44100);
+        var osc = ctx.createOscillator();
+        var comp = ctx.createDynamicsCompressor();
+        osc.type = "triangle";
+        osc.frequency.value = 10000;
+        osc.connect(comp);
+        comp.connect(ctx.destination);
+        osc.start(0);
+        ctx.startRendering().then(function (buffer) {
+          var data = buffer.getChannelData(0);
+          var sum = 0;
+          for (var i = 0; i < data.length; i++) sum += Math.abs(data[i]);
+          var bytes = new Uint8Array(new Float32Array(data.slice(0, 512)).buffer);
+          resolve(hash(bytes) + " (sum of abs samples " + sum.toFixed(6) + ")");
+        }, function () {
+          resolve("rendering failed");
+        });
+      } catch (err) {
+        resolve("unavailable (" + (err && err.message ? err.message : String(err)) + ")");
+      }
+    });
+  }
+
+  function pluginNames() {
+    return safe(function () {
+      var names = [];
+      for (var i = 0; i < navigator.plugins.length; i++) names.push(navigator.plugins[i].name);
+      return names.length ? names.join(", ") : "(none)";
+    });
+  }
+
+  function mimeTypeList() {
+    return safe(function () {
+      var types = [];
+      for (var i = 0; i < navigator.mimeTypes.length; i++) types.push(navigator.mimeTypes[i].type);
+      return types.length ? types.join(", ") : "(none)";
+    });
+  }
+
+  function buildTable(caption, rows) {
+    var table = document.createElement("table");
+    var cap = document.createElement("caption");
+    cap.textContent = caption;
+    table.appendChild(cap);
+    rows.forEach(function (row) {
+      var tr = document.createElement("tr");
+      var th = document.createElement("th");
+      th.textContent = row[0];
+      var td = document.createElement("td");
+      td.className = "value";
+      td.textContent = String(row[1]);
+      tr.appendChild(th);
+      tr.appendChild(td);
+      table.appendChild(tr);
+    });
+    return table;
+  }
+
+  function render(audio) {
+    var gl = webgl();
+    var container = document.getElementById("report");
+    container.textContent = "";
+
+    container.appendChild(
+      buildTable("navigator", [
+        ["userAgent", navigator.userAgent],
+        ["appVersion", navigator.appVersion],
+        ["platform", navigator.platform],
+        ["language", navigator.language],
+        ["languages", (navigator.languages || []).join(", ")],
+        ["hardwareConcurrency", navigator.hardwareConcurrency],
+        ["oscpu", navigator.oscpu || "(not exposed)"],
+      ]),
+    );
+
+    container.appendChild(
+      buildTable("screen and window", [
+        ["screen.width", screen.width],
+        ["screen.height", screen.height],
+        ["screen.availWidth", screen.availWidth],
+        ["screen.availHeight", screen.availHeight],
+        ["screen.colorDepth", screen.colorDepth],
+        ["screen.pixelDepth", screen.pixelDepth],
+        ["devicePixelRatio", window.devicePixelRatio],
+      ]),
+    );
+
+    container.appendChild(
+      buildTable("timezone", [
+        ["Intl timeZone", safe(function () { return new Intl.DateTimeFormat().resolvedOptions().timeZone; })],
+        ["getTimezoneOffset (minutes)", new Date().getTimezoneOffset()],
+      ]),
+    );
+
+    container.appendChild(buildTable("canvas", [["readback hash", canvasHash()]]));
+
+    container.appendChild(
+      buildTable("WebGL", [
+        ["vendor (masked)", gl.vendor],
+        ["renderer (masked)", gl.renderer],
+        ["unmasked vendor", gl.unmaskedVendor || "(not exposed)"],
+        ["unmasked renderer", gl.unmaskedRenderer || "(not exposed)"],
+      ]),
+    );
+
+    container.appendChild(
+      buildTable("plugins and mimeTypes", [
+        ["navigator.plugins", pluginNames()],
+        ["navigator.mimeTypes", mimeTypeList()],
+      ]),
+    );
+
+    container.appendChild(buildTable("Web Audio", [["readback hash", audio]]));
+  }
+
+  audioHash().then(render);
+})();

--- a/testpage/fingerprint.html
+++ b/testpage/fingerprint.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Poison your Trace, fingerprint test page</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, sans-serif;
+      }
+      body {
+        margin: 0 auto;
+        max-width: 60rem;
+        padding: 2rem 1.25rem 4rem;
+        line-height: 1.5;
+      }
+      h1 {
+        font-size: 1.5rem;
+      }
+      p.lede {
+        opacity: 0.85;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1.5rem;
+        font-size: 0.9rem;
+      }
+      caption {
+        text-align: left;
+        font-weight: 600;
+        padding: 0.75rem 0 0.35rem;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 0.4rem 0.6rem;
+        border-bottom: 1px solid rgba(128, 128, 128, 0.3);
+        vertical-align: top;
+        word-break: break-word;
+      }
+      th {
+        width: 14rem;
+        font-weight: 600;
+      }
+      td.value {
+        font-family: ui-monospace, monospace;
+      }
+      .group {
+        font-weight: 700;
+        padding-top: 1.25rem;
+      }
+      footer {
+        margin-top: 2.5rem;
+        opacity: 0.7;
+        font-size: 0.85rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Poison your Trace, fingerprint test page</h1>
+    <p class="lede">
+      This page reads every fingerprint signal Poison your Trace covers in this version and shows the
+      value your browser reports. With the extension enabled, you should see the shared common
+      profile (a Windows 10 Firefox 128, UTC, en US, and neutralized canvas and audio). With the
+      extension disabled, you should see your machine's real values instead.
+    </p>
+    <div id="report">Reading signals...</div>
+    <footer>
+      Signals in scope: navigator (userAgent, appVersion, platform, language, languages,
+      hardwareConcurrency, oscpu), screen (width, height, availWidth, availHeight, colorDepth,
+      pixelDepth, devicePixelRatio), timezone (Intl zone and getTimezoneOffset), canvas readback,
+      WebGL vendor and renderer, navigator plugins and mimeTypes, and Web Audio readback. Font
+      metrics are intentionally not modified in this version.
+    </footer>
+    <script src="fingerprint-test.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #4

## Summary

The foundation already uniformized the in scope signals. This adds the remaining #4 work: capturing, per signal, the real BEFORE value and the applied AFTER value, plumbing them to where the popup (ticket #6) can read them, and a self contained fingerprinting test page.

Each page world override now reads the real value before it replaces a signal and posts a `{ signal, group, before, after }` entry out of the page world. A new isolated world relay forwards those to the background. The header uniformizer reports the real and applied request header values the same way, keyed by tab. The background keeps the latest snapshot per tab in a small store and answers a `poison:getCaptures` message. Snapshots clear on navigation and tab close. Fonts are left untouched, matching the v0 scope, and the uniformize (not randomize) philosophy is preserved.

## Full fingerprint scope (v0, always on)

- navigator basics: userAgent, platform, language, languages, hardwareConcurrency, oscpu, appVersion
- screen: width, height, availWidth, availHeight, colorDepth, pixelDepth, devicePixelRatio
- timezone: the Intl zone and getTimezoneOffset
- canvas readback (neutralized)
- WebGL vendor and renderer
- navigator plugins and mimeTypes
- Web Audio readback (neutralized)
- the User Agent and Accept Language request headers

Font metrics are explicitly NOT modified in this version.

## Before and after data interface (for the popup, #6)

The popup reads a tab's snapshot with a runtime message:

```
browser.runtime.sendMessage({ type: "poison:getCaptures", tabId })
// resolves to { captures: SignalCapture[] }
```

Where `SignalCapture = { signal, group, before, after }`, all strings. `signal` is a stable id (e.g. `navigator.userAgent`, `webgl.renderer`, `header.acceptLanguage`), `group` buckets related rows (navigator, screen, timezone, canvas, webgl, plugins, audio, headers), `before` is the real value with protection off, `after` is the uniformized value. Signals with no scalar (canvas, Web Audio) use `before: "device signature"`, `after: "neutralized"`. The full contract lives in `src/fingerprint/report.ts`.

## Test page

Open `testpage/fingerprint.html` directly in Firefox (drag it into a tab or use a `file://` URL). It reads every in scope signal and shows the common profile when the extension is enabled and your machine's real values when it is disabled. Toggle the extension from the toolbar and reload to compare.

## Checks

`npm run build` and `npm run lint:ext` are both green (zero errors, warnings, notices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)