### PR TITLE
Beginner friendly docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,25 @@ container (so cookies and logins never cross between sites) and your browser fin
 uniformized toward one common profile shared by every user of the extension (so the signals a site
 reads distinguish no one).
 
+## How it works (for a JavaScript newcomer)
+
+A browser extension is made of small scripts that run in two places. A **background script** runs
+once, in the background, for the whole extension: it holds the on and off setting, watches your
+navigation, and rewrites request headers. A **content script** runs inside a web page you visit:
+here the content scripts read and reshape the page's fingerprint and fill email fields.
+
+Some of that reshaping has to reach the page's own JavaScript, not just the extension. Firefox keeps
+a content script in a separate, hidden sandbox (an "isolated world") that the page cannot see. To
+override what the site's own code reads (for example `navigator.userAgent` or a canvas readback),
+the content script injects a tiny `<script>` into the "page world", the same place the site's
+scripts live. That is what "page world injection" means: running our override right next to the
+site's code so the site sees the shared value, not your real one.
+
+Finally, one detail that trips people up: the extension **uniformizes** rather than randomizes. A
+random fingerprint per site or per visit sounds safer but is worse, because a value nobody else has
+is itself a unique label. Instead every user of the extension presents the SAME common profile, so
+the crowd blends together and the signals point at no one in particular.
+
 ## What is uniformized
 
 When enabled, the extension reshapes these signals toward one shared profile:
@@ -22,11 +41,66 @@ When enabled, the extension reshapes these signals toward one shared profile:
 
 Font metrics are not covered yet.
 
+## Burner email autofill
+
+On signup and email fields, the extension fills a unique throwaway address for you, so you do not
+hand a site your real email. The address is built from two everyday dictionary words plus an optional
+number, at the reserved domain `example.invalid`, for example `amber.otter42@example.invalid`.
+
+Why `.invalid`: RFC 2606 and RFC 6761 permanently reserve the `.invalid` top level domain so that it
+can never resolve in the global DNS. No one can register it and no mail server can exist under it, so
+a burner address there is inert by construction. The extension owns no domain, the address reaches no
+real person, and it receives nothing: it is a label, not an inbox.
+
+The address is stable and per site. The same site always gets the same address (so a return visit or
+a login still matches), while different sites get different addresses (so two sites cannot use a
+shared email to link you). It is derived from the site's registrable domain, so every subdomain of a
+site shares one address. The two words are common adjectives and nouns only, never a first or last
+name, so the address reads as an anonymous label rather than anything tied to you.
+
+How it is built: `src/email/generator.ts` turns a domain into the address deterministically,
+`src/email/store.ts` remembers each site's address in `browser.storage.local` so it stays stable
+across visits, and `src/email/autofill.ts` is the content script that finds empty email fields on a
+page and fills them (it never overwrites anything you have already typed).
+
+## What the popup shows
+
+Click the toolbar icon to open the popup. At the top is the **Enabled** toggle, the single on and off
+switch for every protection. Below it is a plain recap of what is being hidden on the site in the
+active tab:
+
+- **This site**: the active container name, and the burner email in use for the site.
+- **The fingerprint, before to after**: every in scope signal grouped by category (Navigator,
+  Screen, Timezone, Canvas, WebGL, Plugins, Audio, Request headers), each shown as its real value
+  "to" the shared common value. Canvas and Audio have no readable value, so they show as "device
+  signature" to "neutralized".
+- **Not hidden**: the honest gaps, stated plainly (the IP is not hidden, use a VPN or Tor for that;
+  email is a burner alias so no mail comes back to you).
+
+Two behaviors to expect:
+
+- **The fingerprint rows fill in after the page loads.** If a tab was already open before you enabled
+  the extension (or before it captured anything), the recap may read "Nothing captured yet on this
+  tab". Reload the page and the rows appear.
+- **The container shows as none at first.** A tab reports "none yet, opens in its own container on
+  next load" until the site's per container tab opens on the next navigation. After that the recap
+  shows the container name.
+
 ## Honest gaps
 
-- Your IP address is not hidden.
-- The extension uniformizes; it does not randomize. A shared, common profile is what makes the
-  crowd blend together.
+Being honest about what this does NOT do matters as much as what it does.
+
+- **Your IP address is not hidden.** The extension shows no IP value in its popup and makes no third
+  party call to look one up, so it never leaks your address by asking about it. But it also cannot
+  change the address a site sees when your browser connects. If you want IP level protection, run a
+  VPN or Tor alongside this extension.
+- **Email is burner only.** The address the extension fills is a throwaway alias at a domain that
+  can never receive mail (see the burner email autofill section above), so no message ever returns to
+  you through it. It hides your real address on signup forms; it is not an inbox.
+- **The extension uniformizes; it does not randomize.** A shared, common profile is what makes the
+  crowd blend together. A random value per site would be a unique label instead, so uniform is the
+  goal, not variety.
+- **Font metrics are not covered yet.**
 
 ## Layout
 
@@ -56,6 +130,10 @@ src/
     report.ts          the before and after capture contract (shape, message tags)
     report-relay.ts    isolated world relay: forwards page world captures to the background
     captures-store.ts  background: per tab before and after snapshot the popup reads
+  email/
+    generator.ts       derives a site's burner address from its domain (two words plus a number)
+    store.ts           remembers each site's burner address in storage so it stays stable
+    autofill.ts        content script: fills empty email fields with the site's burner address
 testpage/
   fingerprint.html     a standalone page that shows every in scope signal
   fingerprint-test.js  reads the signals and renders them grouped


### PR DESCRIPTION
Closes #7

Finalizes the documentation now that all prior tickets (#2 through #6) have landed, so it reflects the real, shipped behavior. Docs only: no runtime changes.

## Sections added or finalized

- **How it works (for a JavaScript newcomer)**: a short, plain narrative on what a background script versus a content script is, what "page world" injection means at a high level, and why one shared profile beats a random one.
- **Burner email autofill (#5)**: explains that on signup and email fields the extension fills a unique per site throwaway address made of two everyday dictionary words plus an optional number at the reserved, non resolving domain example.invalid (RFC 2606 and RFC 6761). Same site reuses its address, different sites differ. Adds the src/email files to the layout tree.
- **What the popup shows (#6)**: describes the Enabled toggle and the recap (container, burner email, before to after fingerprint grouped by category, canvas and audio as "device signature" to "neutralized", and the honest gaps). Documents the two flagged behaviors: fingerprint rows fill after the page loads (an already open tab may need a reload), and the container shows as none until the site's per container tab opens on the next navigation.
- **Honest gaps (expanded)**: IP is not hidden and is never fetched from a third party (suggests a VPN or Tor), email is burner only so no mail returns to the reader, and the uniformize not randomize point is kept.

## Notes

- Every source module under src/ already carries a thorough beginner oriented top comment (email files, popup.ts, captures-store.ts included), so no comment edits were needed.
- No dash characters in new prose.
- `npm run build` and `npm run lint:ext` both stay green (zero errors, warnings, notices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)