### PR TITLE
docs: split beginner guide out of README into docs/ (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,100 +7,62 @@ container (so cookies and logins never cross between sites) and your browser fin
 uniformized toward one common profile shared by every user of the extension (so the signals a site
 reads distinguish no one).
 
-## How it works (for a JavaScript newcomer)
+## Features
 
-A browser extension is made of small scripts that run in two places. A **background script** runs
-once, in the background, for the whole extension: it holds the on and off setting, watches your
-navigation, and rewrites request headers. A **content script** runs inside a web page you visit:
-here the content scripts read and reshape the page's fingerprint and fill email fields.
+- **Per site containers**: every site opens in its own Firefox container, so cookies and logins
+  never cross between sites.
+- **Uniformized fingerprint**: navigator, screen, timezone, canvas, WebGL, plugins, Web Audio, and
+  the User Agent and Accept Language request headers are reshaped toward one common profile shared by
+  every user of the extension, rather than randomized per site.
+- **Burner email autofill**: empty email fields are filled with a unique, stable, per site throwaway
+  alias at the reserved `example.invalid` domain, so you never hand a site your real address.
+- **A single toggle**: one **Enabled** switch in the toolbar popup turns every protection on or off,
+  with a plain recap of what is being hidden on the active site.
 
-Some of that reshaping has to reach the page's own JavaScript, not just the extension. Firefox keeps
-a content script in a separate, hidden sandbox (an "isolated world") that the page cannot see. To
-override what the site's own code reads (for example `navigator.userAgent` or a canvas readback),
-the content script injects a tiny `<script>` into the "page world", the same place the site's
-scripts live. That is what "page world injection" means: running our override right next to the
-site's code so the site sees the shared value, not your real one.
+### Honest gaps
 
-Finally, one detail that trips people up: the extension **uniformizes** rather than randomizes. A
-random fingerprint per site or per visit sounds safer but is worse, because a value nobody else has
-is itself a unique label. Instead every user of the extension presents the SAME common profile, so
-the crowd blends together and the signals point at no one in particular.
-
-## What is uniformized
-
-When enabled, the extension reshapes these signals toward one shared profile:
-
-- navigator basics: userAgent, platform, language, languages, hardwareConcurrency, oscpu, appVersion
-- screen: width, height, availWidth, availHeight, colorDepth, pixelDepth, devicePixelRatio
-- timezone: the Intl zone and getTimezoneOffset
-- canvas readback
-- WebGL vendor and renderer
-- navigator plugins and mimeTypes
-- Web Audio readback
-- the User Agent and Accept Language request headers
-
-Font metrics are not covered yet.
-
-## Burner email autofill
-
-On signup and email fields, the extension fills a unique throwaway address for you, so you do not
-hand a site your real email. The address is built from two everyday dictionary words plus an optional
-number, at the reserved domain `example.invalid`, for example `amber.otter42@example.invalid`.
-
-Why `.invalid`: RFC 2606 and RFC 6761 permanently reserve the `.invalid` top level domain so that it
-can never resolve in the global DNS. No one can register it and no mail server can exist under it, so
-a burner address there is inert by construction. The extension owns no domain, the address reaches no
-real person, and it receives nothing: it is a label, not an inbox.
-
-The address is stable and per site. The same site always gets the same address (so a return visit or
-a login still matches), while different sites get different addresses (so two sites cannot use a
-shared email to link you). It is derived from the site's registrable domain, so every subdomain of a
-site shares one address. The two words are common adjectives and nouns only, never a first or last
-name, so the address reads as an anonymous label rather than anything tied to you.
-
-How it is built: `src/email/generator.ts` turns a domain into the address deterministically,
-`src/email/store.ts` remembers each site's address in `browser.storage.local` so it stays stable
-across visits, and `src/email/autofill.ts` is the content script that finds empty email fields on a
-page and fills them (it never overwrites anything you have already typed).
-
-## What the popup shows
-
-Click the toolbar icon to open the popup. At the top is the **Enabled** toggle, the single on and off
-switch for every protection. Below it is a plain recap of what is being hidden on the site in the
-active tab:
-
-- **This site**: the active container name, and the burner email in use for the site.
-- **The fingerprint, before to after**: every in scope signal grouped by category (Navigator,
-  Screen, Timezone, Canvas, WebGL, Plugins, Audio, Request headers), each shown as its real value
-  "to" the shared common value. Canvas and Audio have no readable value, so they show as "device
-  signature" to "neutralized".
-- **Not hidden**: the honest gaps, stated plainly (the IP is not hidden, use a VPN or Tor for that;
-  email is a burner alias so no mail comes back to you).
-
-Two behaviors to expect:
-
-- **The fingerprint rows fill in after the page loads.** If a tab was already open before you enabled
-  the extension (or before it captured anything), the recap may read "Nothing captured yet on this
-  tab". Reload the page and the rows appear.
-- **The container shows as none at first.** A tab reports "none yet, opens in its own container on
-  next load" until the site's per container tab opens on the next navigation. After that the recap
-  shows the container name.
-
-## Honest gaps
-
-Being honest about what this does NOT do matters as much as what it does.
-
-- **Your IP address is not hidden.** The extension shows no IP value in its popup and makes no third
-  party call to look one up, so it never leaks your address by asking about it. But it also cannot
-  change the address a site sees when your browser connects. If you want IP level protection, run a
-  VPN or Tor alongside this extension.
-- **Email is burner only.** The address the extension fills is a throwaway alias at a domain that
-  can never receive mail (see the burner email autofill section above), so no message ever returns to
-  you through it. It hides your real address on signup forms; it is not an inbox.
-- **The extension uniformizes; it does not randomize.** A shared, common profile is what makes the
-  crowd blend together. A random value per site would be a unique label instead, so uniform is the
-  goal, not variety.
+- **Your IP address is not hidden.** The extension never looks it up or leaks it, but it cannot
+  change the address a site sees. For IP level protection, run a VPN or Tor alongside it.
+- **Email is burner only.** The filled alias is inert by construction and receives nothing; it hides
+  your real address on signup forms, it is not an inbox.
 - **Font metrics are not covered yet.**
+
+For the full reasoning behind these choices (why uniformize rather than randomize, how page world
+injection works, why `.invalid`, what the popup shows, and how to read the fingerprint test page),
+see the [beginner's guide](docs/beginners-guide.md).
+
+## Build and run
+
+You need Node.js and Firefox.
+
+```
+npm install
+npm run build      # typecheck, then bundle into dist/
+npm start          # build, then launch Firefox with the extension loaded (web-ext run)
+npm run lint:ext   # build, then run web-ext lint
+```
+
+To load it by hand in your normal Firefox, open `about:debugging`, choose This Firefox, then Load
+Temporary Add on, and pick `manifest.json`. A temporary add on is unloaded when Firefox restarts,
+so use it only for quick development. For a copy that survives restarts and auto updates, install a
+signed release (see below).
+
+## Install a signed release (auto updating)
+
+Firefox only auto updates signed extensions, so releases are signed through the addons.mozilla.org
+API and self distributed (unlisted). You install the signed xpi once, and every later release lands
+automatically.
+
+One time install:
+
+1. Open the latest release: https://github.com/OptOutRights/poison-your-trace-web-extension/releases/latest
+2. Download the `.xpi` asset.
+3. Drag the `.xpi` file onto a Firefox window (or open it with File, Open File), then confirm the
+   install prompt.
+
+That is the only manual step. The installed extension carries an `update_url` pointing at the
+release copy of `updates.json`, so Firefox checks it periodically and pulls in newer signed builds
+on its own. No reinstall is ever needed for updates.
 
 ## Layout
 
@@ -139,64 +101,6 @@ testpage/
   fingerprint-test.js  reads the signals and renders them grouped
 ```
 
-## Before and after captures (for the popup)
-
-Every override, before it replaces a signal, reads the real value the page would have seen and
-posts a `{ signal, group, before, after }` entry out of the page world. The relay forwards these to
-the background, which keeps the latest snapshot per tab. The popup (ticket #6) reads a tab's
-snapshot by sending a runtime message:
-
-```
-browser.runtime.sendMessage({ type: "poison:getCaptures", tabId })
-// resolves to { captures: SignalCapture[] }
-// SignalCapture = { signal, group, before, after }, all strings
-```
-
-Signals with no scalar value (canvas, Web Audio) report `before: "device signature"` and
-`after: "neutralized"`. The snapshot is cleared when the tab navigates or closes. See `report.ts`
-for the full contract.
-
-## Fingerprint test page
-
-Open `testpage/fingerprint.html` directly in Firefox (drag it into a tab, or use a `file://` URL).
-It reads every in scope signal and shows what your browser reports right now. With the extension
-enabled you see the shared common profile (Windows 10 Firefox 128, UTC, en US, a fixed canvas and
-audio hash); with the extension disabled you see your machine's real values. Toggle the extension
-from the toolbar and reload the page to compare the two.
-
-## Build and run
-
-You need Node.js and Firefox.
-
-```
-npm install
-npm run build      # typecheck, then bundle into dist/
-npm start          # build, then launch Firefox with the extension loaded (web-ext run)
-npm run lint:ext   # build, then run web-ext lint
-```
-
-To load it by hand in your normal Firefox, open `about:debugging`, choose This Firefox, then Load
-Temporary Add on, and pick `manifest.json`. A temporary add on is unloaded when Firefox restarts,
-so use it only for quick development. For a copy that survives restarts and auto updates, install a
-signed release (see below).
-
-## Install a signed release (auto updating)
-
-Firefox only auto updates signed extensions, so releases are signed through the addons.mozilla.org
-API and self distributed (unlisted). You install the signed xpi once, and every later release lands
-automatically.
-
-One time install:
-
-1. Open the latest release: https://github.com/OptOutRights/poison-your-trace-web-extension/releases/latest
-2. Download the `.xpi` asset.
-3. Drag the `.xpi` file onto a Firefox window (or open it with File, Open File), then confirm the
-   install prompt.
-
-That is the only manual step. The installed extension carries an `update_url` pointing at the
-release copy of `updates.json`, so Firefox checks it periodically and pulls in newer signed builds
-on its own. No reinstall is ever needed for updates.
-
 ## How versioning and releases work
 
 Versions follow `MAJOR.MINOR.PATCH`. The single source of truth is the `version` field in
@@ -227,3 +131,9 @@ must add both under Settings, Secrets and variables, Actions before the pipeline
 - `AMO_JWT_SECRET`: the matching JWT secret.
 
 Until both secrets exist, the release workflow stops at the signing step with a clear message.
+
+## Documentation
+
+- [Beginner's guide](docs/beginners-guide.md): a deeper, beginner-friendly walkthrough of how the
+  extension works, what it uniformizes, the burner email rationale, what the popup shows, the honest
+  gaps in full, the before and after capture contract, and the fingerprint test page.

--- a/docs/beginners-guide.md
+++ b/docs/beginners-guide.md
@@ -1,0 +1,125 @@
+# Beginner's guide
+
+An in-depth, beginner-friendly tour of how Poison your Trace works, what it reshapes, and where it is
+honest about its limits. If you just want to install and use the extension, the [README](../README.md)
+covers that; this guide is for readers who want to understand the how and the why.
+
+## How it works (for a JavaScript newcomer)
+
+A browser extension is made of small scripts that run in two places. A **background script** runs
+once, in the background, for the whole extension: it holds the on and off setting, watches your
+navigation, and rewrites request headers. A **content script** runs inside a web page you visit:
+here the content scripts read and reshape the page's fingerprint and fill email fields.
+
+Some of that reshaping has to reach the page's own JavaScript, not just the extension. Firefox keeps
+a content script in a separate, hidden sandbox (an "isolated world") that the page cannot see. To
+override what the site's own code reads (for example `navigator.userAgent` or a canvas readback),
+the content script injects a tiny `<script>` into the "page world", the same place the site's
+scripts live. That is what "page world injection" means: running our override right next to the
+site's code so the site sees the shared value, not your real one.
+
+Finally, one detail that trips people up: the extension **uniformizes** rather than randomizes. A
+random fingerprint per site or per visit sounds safer but is worse, because a value nobody else has
+is itself a unique label. Instead every user of the extension presents the SAME common profile, so
+the crowd blends together and the signals point at no one in particular.
+
+## What is uniformized
+
+When enabled, the extension reshapes these signals toward one shared profile:
+
+- navigator basics: userAgent, platform, language, languages, hardwareConcurrency, oscpu, appVersion
+- screen: width, height, availWidth, availHeight, colorDepth, pixelDepth, devicePixelRatio
+- timezone: the Intl zone and getTimezoneOffset
+- canvas readback
+- WebGL vendor and renderer
+- navigator plugins and mimeTypes
+- Web Audio readback
+- the User Agent and Accept Language request headers
+
+Font metrics are not covered yet.
+
+## Burner email autofill
+
+On signup and email fields, the extension fills a unique throwaway address for you, so you do not
+hand a site your real email. The address is built from two everyday dictionary words plus an optional
+number, at the reserved domain `example.invalid`, for example `amber.otter42@example.invalid`.
+
+Why `.invalid`: RFC 2606 and RFC 6761 permanently reserve the `.invalid` top level domain so that it
+can never resolve in the global DNS. No one can register it and no mail server can exist under it, so
+a burner address there is inert by construction. The extension owns no domain, the address reaches no
+real person, and it receives nothing: it is a label, not an inbox.
+
+The address is stable and per site. The same site always gets the same address (so a return visit or
+a login still matches), while different sites get different addresses (so two sites cannot use a
+shared email to link you). It is derived from the site's registrable domain, so every subdomain of a
+site shares one address. The two words are common adjectives and nouns only, never a first or last
+name, so the address reads as an anonymous label rather than anything tied to you.
+
+How it is built: `src/email/generator.ts` turns a domain into the address deterministically,
+`src/email/store.ts` remembers each site's address in `browser.storage.local` so it stays stable
+across visits, and `src/email/autofill.ts` is the content script that finds empty email fields on a
+page and fills them (it never overwrites anything you have already typed).
+
+## What the popup shows
+
+Click the toolbar icon to open the popup. At the top is the **Enabled** toggle, the single on and off
+switch for every protection. Below it is a plain recap of what is being hidden on the site in the
+active tab:
+
+- **This site**: the active container name, and the burner email in use for the site.
+- **The fingerprint, before to after**: every in scope signal grouped by category (Navigator,
+  Screen, Timezone, Canvas, WebGL, Plugins, Audio, Request headers), each shown as its real value
+  "to" the shared common value. Canvas and Audio have no readable value, so they show as "device
+  signature" to "neutralized".
+- **Not hidden**: the honest gaps, stated plainly (the IP is not hidden, use a VPN or Tor for that;
+  email is a burner alias so no mail comes back to you).
+
+Two behaviors to expect:
+
+- **The fingerprint rows fill in after the page loads.** If a tab was already open before you enabled
+  the extension (or before it captured anything), the recap may read "Nothing captured yet on this
+  tab". Reload the page and the rows appear.
+- **The container shows as none at first.** A tab reports "none yet, opens in its own container on
+  next load" until the site's per container tab opens on the next navigation. After that the recap
+  shows the container name.
+
+## Honest gaps
+
+Being honest about what this does NOT do matters as much as what it does.
+
+- **Your IP address is not hidden.** The extension shows no IP value in its popup and makes no third
+  party call to look one up, so it never leaks your address by asking about it. But it also cannot
+  change the address a site sees when your browser connects. If you want IP level protection, run a
+  VPN or Tor alongside this extension.
+- **Email is burner only.** The address the extension fills is a throwaway alias at a domain that
+  can never receive mail (see the burner email autofill section above), so no message ever returns to
+  you through it. It hides your real address on signup forms; it is not an inbox.
+- **The extension uniformizes; it does not randomize.** A shared, common profile is what makes the
+  crowd blend together. A random value per site would be a unique label instead, so uniform is the
+  goal, not variety.
+- **Font metrics are not covered yet.**
+
+## Before and after captures (for the popup)
+
+Every override, before it replaces a signal, reads the real value the page would have seen and
+posts a `{ signal, group, before, after }` entry out of the page world. The relay forwards these to
+the background, which keeps the latest snapshot per tab. The popup (ticket #6) reads a tab's
+snapshot by sending a runtime message:
+
+```
+browser.runtime.sendMessage({ type: "poison:getCaptures", tabId })
+// resolves to { captures: SignalCapture[] }
+// SignalCapture = { signal, group, before, after }, all strings
+```
+
+Signals with no scalar value (canvas, Web Audio) report `before: "device signature"` and
+`after: "neutralized"`. The snapshot is cleared when the tab navigates or closes. See `report.ts`
+for the full contract.
+
+## Fingerprint test page
+
+Open `testpage/fingerprint.html` directly in Firefox (drag it into a tab, or use a `file://` URL).
+It reads every in scope signal and shows what your browser reports right now. With the extension
+enabled you see the shared common profile (Windows 10 Firefox 128, UTC, en US, a fixed canvas and
+audio hash); with the extension disabled you see your machine's real values. Toggle the extension
+from the toolbar and reload the page to compare the two.


### PR DESCRIPTION
Closes #18.

Splits the long beginner-oriented explanatory prose out of the main README into a new `docs/beginners-guide.md`, so the README stays lean and focused while no information is lost.

## What moved to `docs/beginners-guide.md`

Relocated verbatim (no rewriting, no content lost):

- How it works (for a JavaScript newcomer) — background vs content scripts, page world injection, uniformize vs randomize
- What is uniformized — the full list of reshaped signals
- Burner email autofill — the full rationale, including the RFC 2606 / RFC 6761 `.invalid` reasoning and how the address is derived and stored
- What the popup shows — the detailed popup walkthrough
- Honest gaps — the full detailed version
- Before and after captures (for the popup) — the internal capture contract
- Fingerprint test page — the walkthrough

## What the README keeps

- What the extension is (intro)
- A high-level Features list (containers, uniformized fingerprint, burner email, single toggle)
- A short Honest gaps summary
- Build and run, Install a signed release, Layout, and the release/versioning process

## Links

- README links to the guide from the Features section and from a new Documentation section: `docs/beginners-guide.md`.
- The guide links back to the README: `../README.md`.
- Both relative paths verified to resolve.

## Verification

- Docs-only change; `git status` shows only `README.md` modified and `docs/` added — no accidental non-doc changes.
- `npm install && npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)