### PR TITLE
design: improve extension logo (#10)

### DIFF
--- a/icons/syringe.svg
+++ b/icons/syringe.svg
@@ -1,16 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96" role="img" aria-label="Poison your Trace syringe">
-  <!-- A syringe drawn on the 45 degree diagonal: poison (it neutralizes tracking signals) and a
-       nod to the extension injecting into the page. Single flat green so it reads at 16px. -->
-  <g fill="none" stroke="#0a7d3c" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
-    <!-- barrel -->
-    <rect x="40.5" y="18.5" width="20" height="40" rx="3" transform="rotate(45 50 38)" />
-    <!-- plunger flange at the top -->
-    <line x1="46" y1="12" x2="62" y2="28" />
+  <!--
+    A bold syringe on the 45-degree diagonal: it injects "poison" that neutralizes tracking
+    signals, a nod to the extension writing noise into the page. Chunky, well-separated parts
+    (flange, barrel, needle) and a single flat brand green (#0a7d3c) keep it legible at 16px on
+    light and dark toolbars. Self-contained: no external references, no fonts.
+  -->
+  <g transform="rotate(45 48 48)" fill="#0a7d3c">
     <!-- plunger rod -->
-    <line x1="54" y1="4" x2="66" y2="16" />
-    <!-- needle toward the bottom -->
-    <line x1="52" y1="52" x2="80" y2="80" />
-    <!-- droplet leaving the needle tip -->
-    <circle cx="86" cy="86" r="2.5" fill="#0a7d3c" stroke="none" />
+    <rect x="44" y="8"  width="8"  height="16" rx="4"/>
+    <!-- plunger flange (finger grip) -->
+    <rect x="30" y="22" width="36" height="9"  rx="4"/>
+    <!-- barrel: tall rounded tube -->
+    <rect x="37" y="33" width="22" height="30" rx="6"/>
+    <!-- collar between barrel and needle -->
+    <rect x="42" y="63" width="12" height="6"  rx="2"/>
+    <!-- needle: long and thin so the silhouette reads as a syringe -->
+    <rect x="46" y="69" width="4"  height="24" rx="2"/>
   </g>
 </svg>


### PR DESCRIPTION
Closes #10.

## What changed
Redraws the extension icon (`icons/syringe.svg`) so it reads clearly at 16px on both light and dark toolbars.

The previous icon used thin (5px) strokes and many small strokes plus a tiny detached droplet, which collapsed into an ambiguous blob at toolbar size. The new version keeps the same theme and brand color but uses bold, filled shapes with well-separated parts.

## The new design
- A syringe on the 45-degree diagonal — poison that neutralizes tracking signals, a nod to the extension injecting noise into the page.
- Chunky, well-separated parts: plunger rod, plunger flange (finger grip), rounded barrel, collar, and a long thin needle, so the silhouette reads as a syringe even at 16px.
- Single flat brand green (`#0a7d3c`), which holds contrast on light and dark Firefox toolbars.

## Files
- `icons/syringe.svg` — replaced **in place**. No other files changed.

## Manifest / references
Because the file was replaced in place under the same path, all references stay valid with no edits needed:
- `manifest.json`: `icons` 16/48/96, `browser_action.default_icon`, `page_action.default_icon`
- `popup.html`: `<img src="icons/syringe.svg">`

## Self-contained / offline
Pure inline vector (`<rect>`/`<path>`), a single hard-coded color, no external URLs, no fonts, no emoji-font dependency — renders identically offline and across platforms.

## Verification
- `npm install && npm run build` passes (typecheck + esbuild). The build only emits `dist/*.js`; icons and `popup.html` are served from the repo root, so the manifest path resolves.
- SVG validated as well-formed XML.
- Rendered with `rsvg-convert` at 16/48/96 and on a dark background to confirm legibility at small sizes.

## Known limitations
None re: fonts (no text/emoji used). The icon is a static single-color SVG, so it does not adapt its color to the toolbar theme, but the chosen green has sufficient contrast on both light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)