### PR TITLE
fix: popup before/after diff and verify burner email autofill (#19)

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -36,18 +36,31 @@ const FINGERPRINT_SCRIPTS = [
 
 type RegisteredScript = Awaited<ReturnType<typeof browser.contentScripts.register>>;
 let fingerprintHandles: RegisteredScript[] = [];
+// Guards against a concurrent double registration. applyConfig can run from several triggers at once
+// (module load, onInstalled, onStartup, poison:apply), and setFingerprint awaits between the length
+// check and pushing its handles. Without this flag two overlapping calls could both pass the check and
+// register every fingerprint script twice, so each override would run twice in the same document. The
+// second run would read an already overridden value as its "before", collapsing the popup's before and
+// after to the same text. The flag is set synchronously before the first await, so a second caller
+// sees a registration already in flight and returns.
+let fingerprintRegistering = false;
 
 async function setFingerprint(on: boolean): Promise<void> {
-  if (on && fingerprintHandles.length === 0) {
-    for (const file of FINGERPRINT_SCRIPTS) {
-      fingerprintHandles.push(
-        await browser.contentScripts.register({
-          matches: ["<all_urls>"],
-          js: [{ file }],
-          runAt: "document_start",
-          allFrames: true,
-        }),
-      );
+  if (on && fingerprintHandles.length === 0 && !fingerprintRegistering) {
+    fingerprintRegistering = true;
+    try {
+      for (const file of FINGERPRINT_SCRIPTS) {
+        fingerprintHandles.push(
+          await browser.contentScripts.register({
+            matches: ["<all_urls>"],
+            js: [{ file }],
+            runAt: "document_start",
+            allFrames: true,
+          }),
+        );
+      }
+    } finally {
+      fingerprintRegistering = false;
     }
   } else if (!on && fingerprintHandles.length > 0) {
     for (const handle of fingerprintHandles) await handle.unregister();

--- a/src/fingerprint/audio.ts
+++ b/src/fingerprint/audio.ts
@@ -26,6 +26,12 @@ import { REPORT_MESSAGE_TYPE, OPAQUE_BEFORE, NEUTRALIZED_AFTER } from "./report"
  *   buffer, so a sum of absolute samples becomes exactly zero).
  */
 function pageWorldOverride(fill: number, reportType: string, opaqueBefore: string, neutralized: string): void {
+  // Run at most once per document, so a second injection into the same page does not re-patch the
+  // read paths or post a duplicate capture batch.
+  const guard = window as unknown as { __poisonAudioDone?: boolean };
+  if (guard.__poisonAudioDone) return;
+  guard.__poisonAudioDone = true;
+
   // Replace a prototype method, tolerating a missing or frozen prototype rather than throwing.
   const patch = (proto: object | undefined, name: string, impl: (...args: never[]) => unknown): void => {
     try {

--- a/src/fingerprint/inject.ts
+++ b/src/fingerprint/inject.ts
@@ -20,6 +20,14 @@ import { REPORT_MESSAGE_TYPE, OPAQUE_BEFORE, NEUTRALIZED_AFTER } from "./report"
  * world without importing anything.
  */
 function pageWorldOverride(p: CommonProfile, reportType: string, opaqueBefore: string, neutralized: string): void {
+  // Run at most once per document. If this override is injected twice into the same page (e.g. a
+  // race that registers the content script twice), a second run would read the value we already
+  // overrode as its "before", collapsing the popup's before and after to the same text. The guard
+  // makes the override idempotent so the recorded "before" is always the page's real value.
+  const guard = window as unknown as { __poisonFingerprintDone?: boolean };
+  if (guard.__poisonFingerprintDone) return;
+  guard.__poisonFingerprintDone = true;
+
   // Collected before and after pairs, posted to the isolated world relay at the end of the run.
   const captures: { signal: string; group: string; before: string; after: string }[] = [];
   const toStr = (v: unknown): string => {

--- a/src/fingerprint/plugins.ts
+++ b/src/fingerprint/plugins.ts
@@ -43,6 +43,13 @@ function pageWorldOverride(
   mimes: readonly { type: string; suffixes: string; description: string }[],
   reportType: string,
 ): void {
+  // Run at most once per document. A second injection into the same page would read our already
+  // overridden navigator.plugins and navigator.mimeTypes as its "before", collapsing the popup's
+  // before and after to the same text, so the guard keeps the override idempotent.
+  const guard = window as unknown as { __poisonPluginsDone?: boolean };
+  if (guard.__poisonPluginsDone) return;
+  guard.__poisonPluginsDone = true;
+
   const define = (obj: object, prop: string, value: unknown): void => {
     try {
       Object.defineProperty(obj, prop, { get: () => value, configurable: true, enumerable: true });

--- a/src/fingerprint/webgl.ts
+++ b/src/fingerprint/webgl.ts
@@ -32,6 +32,13 @@ const WEBGL_UNMASKED_RENDERER = "ANGLE (Intel, Intel(R) UHD Graphics 620 Direct3
  * passed in so it can post its before and after captures out of the page world without importing.
  */
 function pageWorldOverride(masked: string, unmaskedVendor: string, unmaskedRenderer: string, reportType: string): void {
+  // Run at most once per document. A second injection into the same page would read our already
+  // masked vendor and renderer as its "before", collapsing the popup's before and after to the same
+  // text, so the guard keeps the override idempotent and the recorded "before" real.
+  const guard = window as unknown as { __poisonWebglDone?: boolean };
+  if (guard.__poisonWebglDone) return;
+  guard.__poisonWebglDone = true;
+
   // Numeric enum values for the intercepted parameters. These are fixed by the WebGL and extension
   // specs, so hard coding them avoids depending on a live context: VENDOR and RENDERER are core GL
   // enums; the UNMASKED_* pair comes from WEBGL_debug_renderer_info.


### PR DESCRIPTION
## Summary

Fixes issue #19, which raised three concerns about the popup recap. Diagnosis and outcome below.

### 1. Before(red) / after(green) diff always shows the same text — FIXED
The popup binds the right fields (`cap.before` to the red span, `cap.after` to the teal span in `src/popup.ts`), and every page world override reads the real value *before* overriding it. The genuine bug was **double injection**:

- `applyConfig()` runs from several triggers (module load, `onInstalled`, `onStartup`, `poison:apply`). `setFingerprint(true)` checks `fingerprintHandles.length === 0` and then `await`s the registration loop. Two overlapping calls could both pass that check before either pushed a handle, registering every fingerprint content script **twice**.
- On its second run in the same document, `pageWorldOverride` reads `navigator.userAgent` (etc.) which it *already overrode*, so `before` equals `after`. Because the capture store keys by signal, the corrupted second batch overwrites the good first one, and the popup shows identical text.

Fix:
- `src/background.ts`: guard registration with a synchronous `fingerprintRegistering` in-flight flag so scripts register once.
- `src/fingerprint/{inject,webgl,audio,plugins}.ts`: make each page world override idempotent with a per-document `window` sentinel, so any duplicate injection can never corrupt the recorded `before` (defense in depth).

### 2. Is the burner email actually applied? — VERIFIED, no bug
`src/email/autofill.ts` is registered as a content script only while the extension is enabled (`src/background.ts`). It asks the background for `poison:burner` with `location.hostname`; the background answers with `getBurnerFor(hostname)` — the **same** function the popup uses to display the address. So the shown address is exactly the one filled into empty email fields (`input[type=email]` and name/id/placeholder/aria-label heuristics), with input/change events dispatched. No code change needed. Known design limitation: autofill runs at `document_idle` plus a 10s MutationObserver, so email fields that appear more than 10s after load are not filled.

### 3. GitHub lighter than YouTube — EXPECTED, no bug
The JS-layer captures (navigator/screen/timezone/canvas/webgl/audio/plugins) are posted by page world `<script>` injections, which a strict Content Security Policy (github.com) blocks — this is the documented CSP seam in `inject.ts`/`webgl.ts`/etc. The header captures (User-Agent, Accept-Language) come from the network layer via `webRequest` and are unaffected by CSP, so they still appear. That is why github.com's list is lighter: fewer JS captures get through, not a list-logic bug.

## Verification
`npm install` then `npm run build` (typecheck + esbuild) passes. Confirmed the window guards serialize into the page world bundles and the registration flag is present in `dist/background.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)