### PR TITLE
docs: make signed release installable by any user (#27)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,18 @@ jobs:
           echo "path=$xpi_path" >> "$GITHUB_OUTPUT"
           echo "name=$(basename "$xpi_path")" >> "$GITHUB_OUTPUT"
 
+      - name: Copy the signed xpi under a stable name
+        id: stable
+        # web-ext sign names the file per version (poison_your_trace-0.1.1.xpi), so its download URL
+        # changes every release. A fixed-name copy gives a permanent link,
+        # releases/latest/download/poison-your-trace.xpi, that the README can point at and that
+        # never rots between releases. The versioned asset stays too: updates.json's update_link
+        # references it at its per version path for auto updates.
+        run: |
+          stable_path="web-ext-artifacts/poison-your-trace.xpi"
+          cp "${{ steps.xpi.outputs.path }}" "$stable_path"
+          echo "path=$stable_path" >> "$GITHUB_OUTPUT"
+
       - name: Generate updates.json
         run: node scripts/build-updates-json.mjs "${{ steps.version.outputs.version }}" "${{ steps.xpi.outputs.name }}"
 
@@ -95,4 +107,5 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             ${{ steps.xpi.outputs.path }}
+            ${{ steps.stable.outputs.path }}
             updates.json

--- a/README.md
+++ b/README.md
@@ -50,19 +50,27 @@ signed release (see below).
 ## Install a signed release (auto updating)
 
 Firefox only auto updates signed extensions, so releases are signed through the addons.mozilla.org
-API and self distributed (unlisted). You install the signed xpi once, and every later release lands
-automatically.
+API and self distributed (unlisted). Because the build is signed, **anyone can install it on a
+normal Firefox** with no developer settings and nothing from the maintainer: the signature is what
+Firefox checks, not who is installing. You install the signed xpi once, and every later release
+lands automatically.
 
-One time install:
+Install in Firefox (one time):
 
-1. Open the latest release: https://github.com/OptOutRights/poison-your-trace-web-extension/releases/latest
-2. Download the `.xpi` asset.
-3. Drag the `.xpi` file onto a Firefox window (or open it with File, Open File), then confirm the
-   install prompt.
+1. In Firefox, open the permanent install link:
+   **https://github.com/OptOutRights/poison-your-trace-web-extension/releases/latest/download/poison-your-trace.xpi**
+2. Firefox downloads the `.xpi` and offers to add it. Open it from the download prompt (or the
+   Downloads panel) and confirm **Add**.
 
-That is the only manual step. The installed extension carries an `update_url` pointing at the
-release copy of `updates.json`, so Firefox checks it periodically and pulls in newer signed builds
-on its own. No reinstall is ever needed for updates.
+That link always points at the newest signed release, so it never goes stale between versions. Once
+installed, the extension carries an `update_url` pointing at the release copy of `updates.json`, so
+Firefox checks it periodically and pulls in newer signed builds on its own. No reinstall is ever
+needed for updates.
+
+> Why this works for everyone: an unlisted build signed by addons.mozilla.org installs on stock
+> Firefox exactly like a listed one. The maintainer's own shortcut (dropping a local, unsigned dev
+> `.xpi` into the address bar) only works because their Firefox relaxes signature enforcement; the
+> signed release above needs none of that, so it is the path to share with other users.
 
 ## Layout
 


### PR DESCRIPTION
Closes #27.

## Problem
The maintainer's personal install trick — dropping a local `.xpi` into the address bar — only works because their Firefox relaxes signature enforcement. It can't be handed to other users. The *release* `.xpi` is already AMO-signed (`--channel=unlisted`), so it installs on any stock Firefox with nothing from the maintainer — but the only release asset had a version-stamped name, so there was no permanent link to share.

## Change
- **`.github/workflows/release.yml`**: after signing, copy the signed `.xpi` to a fixed name `poison-your-trace.xpi` and attach it alongside the versioned asset. This yields a permanent install URL that never rots between versions: `…/releases/latest/download/poison-your-trace.xpi`. The versioned asset stays, so `updates.json`'s `update_link` (auto-update) is unchanged.
- **`README.md`**: rewrite the install section around that permanent link with honest one-click steps, and explain why an AMO-signed unlisted build installs for anyone.

## Note on installation friction
Clicking a GitHub release `.xpi` link downloads-then-prompts-to-Add (GitHub serves it as an attachment). That's as frictionless as GitHub self-distribution allows; the true one-click `InstallTrigger` flow was removed in Firefox 128. The README reflects this honestly, and it's the natural spot for a walkthrough video.

## Testing
Can't be exercised here: the workflow only runs on a `vX.Y.Z` tag push and needs the `AMO_JWT_ISSUER`/`AMO_JWT_SECRET` secrets. The permanent-link asset only appears after a real signed release. Statically verified:
- `npm run typecheck` clean (no code touched)
- `release.yml` validated as YAML
- Code review confirmed step ordering keeps `updates.json`'s update_link on the versioned name, `fail_on_unmatched_files` still holds, and the Firefox 128+ claims are accurate.