### PR TITLE
Workers & OffscreenCanvas fingerprint parity (#38)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -25,6 +25,7 @@ await build({
     background: "src/background.ts",
     popup: "src/popup.ts",
     fingerprint: "src/fingerprint/inject.ts",
+    "fingerprint-workers": "src/fingerprint/workers.ts",
     "fingerprint-webgl": "src/fingerprint/webgl.ts",
     "fingerprint-audio": "src/fingerprint/audio.ts",
     "fingerprint-plugins": "src/fingerprint/plugins.ts",

--- a/src/background.ts
+++ b/src/background.ts
@@ -53,12 +53,16 @@ const headers = new HeaderUniformizer(
 );
 
 // The page world scripts that make up fingerprint uniformization. `fingerprint.js` is the base
-// (navigator, screen, timezone, canvas); the others cover WebGL, Web Audio, and plugins/mimeTypes.
-// They run in the page's MAIN world (world: "MAIN") so the overrides apply directly to the page's
-// own globals and are visible to the site's scripts, and — unlike the old inline <script> injection
-// — survive a strict page Content Security Policy because the browser injects them, not the DOM.
+// (navigator, screen, timezone, canvas); `fingerprint-workers.js` extends that same profile into
+// Web Workers by wrapping the Worker/SharedWorker constructors (ticket #38); the others cover WebGL,
+// Web Audio, and plugins/mimeTypes. They run in the page's MAIN world (world: "MAIN") so the
+// overrides apply directly to the page's own globals and are visible to the site's scripts, and —
+// unlike the old inline <script> injection — survive a strict page Content Security Policy because
+// the browser injects them, not the DOM. The worker hook is registered before any site script so it
+// wraps the constructors before a page can spawn a worker.
 const FINGERPRINT_OVERRIDE_SCRIPTS = [
   "dist/fingerprint.js",
+  "dist/fingerprint-workers.js",
   "dist/fingerprint-webgl.js",
   "dist/fingerprint-audio.js",
   "dist/fingerprint-plugins.js",

--- a/src/fingerprint/inject.ts
+++ b/src/fingerprint/inject.ts
@@ -143,6 +143,32 @@ function pageWorldOverride(p: CommonProfile, reportType: string, opaqueBefore: s
     ctxProto.getImageData = function getImageData(_x, _y, w, h) {
       return new ImageData(Math.max(1, w | 0), Math.max(1, h | 0));
     };
+
+    // OffscreenCanvas is a second canvas surface usable on the main thread too (via
+    // new OffscreenCanvas(...) or HTMLCanvasElement.transferControlToOffscreen()), with its own
+    // readback paths that bypass the HTMLCanvasElement patch above: convertToBlob() and the 2D
+    // context's getImageData(). Left alone they leak the same device drawn signature, so neutralize
+    // them identically — encode a FRESH blank OffscreenCanvas of the same size, and hand back
+    // transparent pixels — keeping the main-thread canvas signal consistent whichever surface a site
+    // reads. (The worker-side copy of this same neutralization lives in workers.ts.)
+    const offscreenCtor = (window as unknown as {
+      OffscreenCanvas?: { prototype: { convertToBlob?: (...args: unknown[]) => Promise<Blob> } } & (new (w: number, h: number) => { width: number; height: number });
+    }).OffscreenCanvas;
+    if (offscreenCtor && typeof offscreenCtor.prototype.convertToBlob === "function") {
+      const origConvertToBlob = offscreenCtor.prototype.convertToBlob;
+      offscreenCtor.prototype.convertToBlob = function convertToBlob(this: { width: number; height: number }, ...args: unknown[]): Promise<Blob> {
+        const blank = new offscreenCtor(Math.max(1, this.width | 0), Math.max(1, this.height | 0));
+        return origConvertToBlob.apply(blank, args);
+      };
+    }
+    const offscreenCtxProto = (window as unknown as {
+      OffscreenCanvasRenderingContext2D?: { prototype: { getImageData?: (x: number, y: number, w: number, h: number) => ImageData } };
+    }).OffscreenCanvasRenderingContext2D?.prototype;
+    if (offscreenCtxProto && typeof offscreenCtxProto.getImageData === "function") {
+      offscreenCtxProto.getImageData = function getImageData(_x, _y, w, h) {
+        return new ImageData(Math.max(1, w | 0), Math.max(1, h | 0));
+      };
+    }
     // Canvas readback has no scalar value to compare, so we report the agreed sentinels: the real
     // device drawn signature before, neutralized after.
     record("canvas.readback", "canvas", opaqueBefore, neutralized);

--- a/src/fingerprint/workers.ts
+++ b/src/fingerprint/workers.ts
@@ -1,0 +1,214 @@
+// Content script, registered at document_start in the page's MAIN world when the extension is
+// enabled. Extends fingerprint uniformization INTO Web Workers.
+//
+// Why this file exists: the sibling overrides (inject.ts, webgl.ts, ...) patch the page's `window`
+// globals, but a Worker runs in its OWN global scope with a separate WorkerNavigator and its own
+// OffscreenCanvas / WebGL contexts — none of the window patches reach it. A page that spoofs only
+// the window therefore leaks the REAL values the moment a script reads them from inside a worker,
+// and that window-vs-worker MISMATCH is itself a stable identifier CreepJS specifically probes for.
+// Closing it is the single biggest remaining detector gap (ticket #38).
+//
+// Mechanism (the standard, and only, content-script-reachable approach — see the ticket #38 research
+// note): we cannot reach into a worker realm after it exists, so we prepend our overrides to the
+// worker SOURCE. The wrapped Worker/SharedWorker constructor builds a tiny bootstrap — the serialized
+// override function invoked with the resolved profile, then importScripts()/import() of the site's
+// original (absolute) URL — wraps it in a Blob, and hands the real constructor the blob URL. The
+// worker thus applies our profile synchronously before a single line of the site's worker code runs.
+//
+// The override body (applyWorkerOverrides) is deliberately SELF-CONTAINED: it references only its
+// argument and worker globals, never this module's scope, because it is serialized with toString()
+// and re-parsed in a fresh realm. That forces a small amount of duplication with the window-side
+// overrides (the WebGL enums, the blank-canvas readback), which is intrinsic to crossing realms.
+//
+// Known limitations (documented, not bugs):
+//   - A page whose Content-Security-Policy forbids blob/worker sources (e.g. `worker-src 'self'`)
+//     rejects the blob-URL worker, so the worker either loads unspoofed or fails — the inherent
+//     blob/CSP tradeoff of worker injection. We fail OPEN (fall back to the untouched constructor)
+//     for anything we can catch synchronously, so we never break a worker we can avoid breaking.
+//   - Service workers are NOT covered here: their script URL must be a same-origin http(s) resource,
+//     so a blob bootstrap is rejected by the browser. Covering them needs a background webRequest
+//     response rewrite (deferred) — see the PR notes.
+//   - A wrapped SharedWorker is keyed by its per-document blob URL, so cross-document sharing of the
+//     same SharedWorker no longer coalesces to one instance (intra-document reuse is preserved via
+//     the blob cache below).
+
+import { resolveProfileFromPage, type CommonProfile } from "./profiles";
+
+/**
+ * Applied INSIDE a worker's global scope. Serialized with toString() into the bootstrap blob, so it
+ * must rely ONLY on its argument and standard worker globals — never on this module's imports or
+ * scope. Mirrors the window-side overrides for the signals a worker actually exposes:
+ *   - WorkerNavigator (userAgent, appVersion, platform, language, languages, hardwareConcurrency).
+ *     No oscpu / plugins / mimeTypes / screen in a worker, so those are simply absent, not spoofed.
+ *   - timezone: Intl.DateTimeFormat().resolvedOptions().timeZone and Date.getTimezoneOffset(), which
+ *     do exist in a worker and must agree with the window.
+ *   - OffscreenCanvas readback (convertToBlob, 2D getImageData), the worker canvas surface.
+ *   - WebGL vendor/renderer masking on OffscreenCanvas-backed contexts.
+ * Web Audio has no worker surface (AudioContext is window-only), so there is nothing to do there.
+ */
+function applyWorkerOverrides(p: CommonProfile): void {
+  const scope = self as unknown as {
+    __poisonWorkerDone?: boolean;
+    navigator: Record<string, unknown>;
+    OffscreenCanvas?: (new (w: number, h: number) => { width: number; height: number }) & {
+      prototype: { convertToBlob?: (...args: unknown[]) => Promise<Blob> };
+    };
+    OffscreenCanvasRenderingContext2D?: { prototype: { getImageData?: (x: number, y: number, w: number, h: number) => ImageData } };
+    WebGLRenderingContext?: { prototype: { getParameter?: (pname: number) => unknown } };
+    WebGL2RenderingContext?: { prototype: { getParameter?: (pname: number) => unknown } };
+  };
+  // Run at most once per worker realm, so a double bootstrap cannot re-wrap the already-wrapped
+  // read paths.
+  if (scope.__poisonWorkerDone) return;
+  scope.__poisonWorkerDone = true;
+
+  const define = (obj: object, prop: string, value: unknown): void => {
+    try {
+      Object.defineProperty(obj, prop, { get: () => value, configurable: true, enumerable: true });
+    } catch {
+      /* non configurable on this engine: skip rather than throw into the worker */
+    }
+  };
+
+  // navigator (WorkerNavigator). Same values the window presents, so window == worker.
+  try {
+    const nav = scope.navigator;
+    define(nav, "userAgent", p.ua);
+    define(nav, "appVersion", p.ua.replace("Mozilla/", ""));
+    define(nav, "platform", p.platform);
+    define(nav, "language", p.language);
+    define(nav, "languages", Object.freeze([...p.languages]));
+    define(nav, "hardwareConcurrency", p.hardwareConcurrency);
+  } catch {
+    /* WorkerNavigator missing or frozen: leave it untouched */
+  }
+
+  // timezone: Intl.resolvedOptions().timeZone and Date.getTimezoneOffset must agree, matching inject.ts.
+  try {
+    const origResolved = Intl.DateTimeFormat.prototype.resolvedOptions;
+    Intl.DateTimeFormat.prototype.resolvedOptions = function resolvedOptions() {
+      const opts = origResolved.call(this);
+      opts.timeZone = p.timezone;
+      return opts;
+    };
+    Date.prototype.getTimezoneOffset = function getTimezoneOffset() {
+      return p.timezoneOffsetMinutes;
+    };
+  } catch {
+    /* engine rejected the timezone patch: leave it untouched */
+  }
+
+  // OffscreenCanvas readback: encode a fresh blank canvas of the same size for convertToBlob, and hand
+  // back transparent pixels for the 2D getImageData path — identical neutralization to inject.ts.
+  try {
+    const OffscreenCtor = scope.OffscreenCanvas;
+    if (OffscreenCtor && typeof OffscreenCtor.prototype.convertToBlob === "function") {
+      const origConvertToBlob = OffscreenCtor.prototype.convertToBlob;
+      OffscreenCtor.prototype.convertToBlob = function convertToBlob(this: { width: number; height: number }, ...args: unknown[]): Promise<Blob> {
+        const blank = new OffscreenCtor(Math.max(1, this.width | 0), Math.max(1, this.height | 0));
+        return origConvertToBlob.apply(blank, args);
+      };
+    }
+    const offCtxProto = scope.OffscreenCanvasRenderingContext2D?.prototype;
+    if (offCtxProto && typeof offCtxProto.getImageData === "function") {
+      offCtxProto.getImageData = function getImageData(_x, _y, w, h) {
+        return new ImageData(Math.max(1, w | 0), Math.max(1, h | 0));
+      };
+    }
+  } catch {
+    /* no OffscreenCanvas in this worker: nothing to neutralize */
+  }
+
+  // WebGL vendor/renderer masking, identical to webgl.ts: masked core VENDOR/RENDERER return Firefox's
+  // constant "Mozilla", the debug-renderer UNMASKED_* pair returns the per-family common GPU identity.
+  try {
+    const VENDOR = 0x1f00;
+    const RENDERER = 0x1f01;
+    const UNMASKED_VENDOR_WEBGL = 0x9245;
+    const UNMASKED_RENDERER_WEBGL = 0x9246;
+    const masked = "Mozilla";
+    const unmaskedVendor = p.webgl.unmaskedVendor;
+    const unmaskedRenderer = p.webgl.unmaskedRenderer;
+    const patch = (proto: { getParameter?: (pname: number) => unknown } | undefined): void => {
+      if (!proto || typeof proto.getParameter !== "function") return;
+      const original = proto.getParameter;
+      proto.getParameter = function getParameter(this: unknown, parameter: number): unknown {
+        if (parameter === VENDOR || parameter === RENDERER) return masked;
+        if (parameter === UNMASKED_VENDOR_WEBGL) return unmaskedVendor;
+        if (parameter === UNMASKED_RENDERER_WEBGL) return unmaskedRenderer;
+        return original.call(this, parameter);
+      };
+    };
+    if (scope.WebGLRenderingContext) patch(scope.WebGLRenderingContext.prototype);
+    if (scope.WebGL2RenderingContext) patch(scope.WebGL2RenderingContext.prototype);
+  } catch {
+    /* no WebGL in this worker: nothing to mask */
+  }
+}
+
+// This file IS the page's MAIN world, so wrap the constructors directly. Resolve the same profile the
+// window overrides use: the background injects window.__poisonOsFamily before these scripts, so both
+// layers present the same family (falling back to the real navigator if that global is absent).
+installWorkerHooks(resolveProfileFromPage(window));
+
+function installWorkerHooks(profile: CommonProfile): void {
+  // Run at most once per document, so a second injection cannot double-wrap the constructors.
+  const guard = window as unknown as { __poisonWorkersDone?: boolean };
+  if (guard.__poisonWorkersDone) return;
+  guard.__poisonWorkersDone = true;
+
+  // The bootstrap prefix: the serialized override, invoked with the frozen-in profile. Built once.
+  const overrideSource = `(${applyWorkerOverrides.toString()})(${JSON.stringify(profile)});`;
+
+  // Blob URLs are cached by (module/classic, name, absolute URL) so repeated constructions with the
+  // same arguments reuse one URL — this both avoids blob churn and preserves a SharedWorker's
+  // intra-document identity (a SharedWorker is keyed by URL + name, so a stable URL keeps same-page
+  // constructions coalescing to one instance).
+  const blobCache = new Map<string, string>();
+
+  const bootstrapURL = (scriptURL: string | URL, options: unknown): string => {
+    const absolute = new URL(String(scriptURL), location.href).href;
+    const opts = options && typeof options === "object" ? (options as { type?: string; name?: string }) : {};
+    // SharedWorker's second argument may be a plain string name instead of an options bag.
+    const name = typeof options === "string" ? options : typeof opts.name === "string" ? opts.name : "";
+    const isModule = opts.type === "module";
+    const key = `${isModule ? "m" : "c"} ${name} ${absolute}`;
+    const cached = blobCache.get(key);
+    if (cached) return cached;
+    // A module worker cannot importScripts (it is not defined there), so pull the original in with a
+    // dynamic import(); a classic worker uses importScripts(). Either way the original runs AFTER our
+    // synchronous overrides, from its real absolute URL so its own relative imports still resolve.
+    const load = isModule ? `import(${JSON.stringify(absolute)});` : `importScripts(${JSON.stringify(absolute)});`;
+    const blobURL = URL.createObjectURL(new Blob([`${overrideSource}\n${load}`], { type: "text/javascript" }));
+    blobCache.set(key, blobURL);
+    return blobURL;
+  };
+
+  // Wrap a worker constructor via a Proxy so the exotic parts of the original (its .prototype, .name,
+  // instanceof, and subclassing through `class X extends Worker`) are preserved untouched — only the
+  // scriptURL argument is swapped for the bootstrap blob. Any failure building the blob falls back to
+  // the untouched construction so we never break a worker the site depends on.
+  const wrap = <T extends abstract new (...args: never[]) => object>(Ctor: T): T =>
+    new Proxy(Ctor, {
+      construct(target, argArray, newTarget): object {
+        try {
+          const [scriptURL, options] = argArray as [string | URL, unknown];
+          const url = bootstrapURL(scriptURL, options);
+          return Reflect.construct(target, [url, options] as never[], newTarget);
+        } catch {
+          return Reflect.construct(target, argArray as never[], newTarget);
+        }
+      },
+    });
+
+  const g = window as unknown as {
+    Worker?: abstract new (...args: never[]) => object;
+    SharedWorker?: abstract new (...args: never[]) => object;
+  };
+  if (typeof g.Worker === "function") g.Worker = wrap(g.Worker);
+  if (typeof g.SharedWorker === "function") g.SharedWorker = wrap(g.SharedWorker);
+}
+
+// Module scope (no runtime export): keeps applyWorkerOverrides / installWorkerHooks file local so
+// they do not collide with the sibling fingerprint content scripts in tsc's global script scope.
+export {};

--- a/src/fingerprint/workers.ts
+++ b/src/fingerprint/workers.ts
@@ -175,10 +175,14 @@ function installWorkerHooks(profile: CommonProfile): void {
     const key = `${isModule ? "m" : "c"} ${name} ${absolute}`;
     const cached = blobCache.get(key);
     if (cached) return cached;
-    // A module worker cannot importScripts (it is not defined there), so pull the original in with a
-    // dynamic import(); a classic worker uses importScripts(). Either way the original runs AFTER our
-    // synchronous overrides, from its real absolute URL so its own relative imports still resolve.
-    const load = isModule ? `import(${JSON.stringify(absolute)});` : `importScripts(${JSON.stringify(absolute)});`;
+    // Pull the site's original script in AFTER our synchronous overrides, from its real absolute URL
+    // so its own relative imports/importScripts still resolve. A classic worker uses the synchronous
+    // importScripts(), so the original (including any onmessage it installs) runs to completion before
+    // the worker's event loop starts. A module worker cannot importScripts, so it uses top-level
+    // `await import()`: the await keeps the bootstrap module evaluating — and the worker's message
+    // queue therefore paused — until the original module has evaluated and wired up its handlers, so a
+    // message the page posts right after `new Worker(...)` is not dropped on the floor.
+    const load = isModule ? `await import(${JSON.stringify(absolute)});` : `importScripts(${JSON.stringify(absolute)});`;
     const blobURL = URL.createObjectURL(new Blob([`${overrideSource}\n${load}`], { type: "text/javascript" }));
     blobCache.set(key, blobURL);
     return blobURL;

--- a/testpage/fingerprint-test.js
+++ b/testpage/fingerprint-test.js
@@ -148,6 +148,84 @@
     });
   }
 
+  // Source for a dedicated worker that reads the same signals from INSIDE a worker realm and posts
+  // them back. A worker has its own WorkerNavigator and OffscreenCanvas, so without the extension's
+  // worker injection these return the real device values while the window shows the common profile —
+  // the window-vs-worker mismatch CreepJS flags. With the extension on and issue #38 applied, the
+  // worker reports the SAME common profile as the window. Runs immediately on startup and postMessages
+  // one result object. Kept as a string so the page can spawn it from a Blob with no build step.
+  var WORKER_SOURCE = [
+    "(function(){",
+    "  var out = {};",
+    "  function read(k, fn){ try { out[k] = String(fn()); } catch (e) { out[k] = 'err'; } }",
+    "  read('userAgent', function(){ return navigator.userAgent; });",
+    "  read('appVersion', function(){ return navigator.appVersion; });",
+    "  read('platform', function(){ return navigator.platform; });",
+    "  read('language', function(){ return navigator.language; });",
+    "  read('languages', function(){ return (navigator.languages || []).join(', '); });",
+    "  read('hardwareConcurrency', function(){ return navigator.hardwareConcurrency; });",
+    "  read('timezone', function(){ return new Intl.DateTimeFormat().resolvedOptions().timeZone; });",
+    "  read('offset', function(){ return new Date().getTimezoneOffset(); });",
+    "  try {",
+    "    if (typeof OffscreenCanvas !== 'undefined') {",
+    "      var c = new OffscreenCanvas(220, 40);",
+    "      var ctx = c.getContext('2d');",
+    "      ctx.fillStyle = '#f60'; ctx.fillRect(2, 2, 120, 22);",
+    "      ctx.fillStyle = '#069'; ctx.fillText('Poison \\u{1F489}', 4, 4);",
+    "      var px = ctx.getImageData(0, 0, c.width, c.height).data;",
+    "      var neutral = true;",
+    "      for (var i = 0; i < px.length; i++) { if (px[i] !== 0) { neutral = false; break; } }",
+    "      out.canvasNeutralized = neutral;",
+    "      var gc = new OffscreenCanvas(1, 1);",
+    "      var gl = gc.getContext('webgl');",
+    "      if (gl) {",
+    "        var dbg = gl.getExtension('WEBGL_debug_renderer_info');",
+    "        if (dbg) {",
+    "          out.webglUnmaskedVendor = String(gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL));",
+    "          out.webglUnmaskedRenderer = String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL));",
+    "        }",
+    "      }",
+    "    }",
+    "  } catch (e) { /* no OffscreenCanvas in this worker */ }",
+    "  self.postMessage(out);",
+    "})();",
+  ].join("\n");
+
+  // Spawn the worker from a Blob and resolve with its posted signals, or with { unavailable } if the
+  // worker cannot run — under a strict CSP (default-src/worker-src without blob:) the browser blocks
+  // blob workers entirely, so this degrades to an info row rather than a false failure.
+  function workerProbe() {
+    return new Promise(function (resolve) {
+      var w = null;
+      var done = false;
+      function finish(v) {
+        if (done) return;
+        done = true;
+        try {
+          if (w) w.terminate();
+        } catch (e) {
+          /* already gone */
+        }
+        resolve(v);
+      }
+      try {
+        var url = URL.createObjectURL(new Blob([WORKER_SOURCE], { type: "text/javascript" }));
+        w = new Worker(url);
+        w.onmessage = function (ev) {
+          finish(ev.data);
+        };
+        w.onerror = function (ev) {
+          finish({ unavailable: (ev && ev.message) || "worker blocked (likely CSP)" });
+        };
+        setTimeout(function () {
+          finish({ unavailable: "worker timed out (blocked or unsupported)" });
+        }, 2000);
+      } catch (e) {
+        finish({ unavailable: "cannot create worker (" + (e && e.message ? e.message : String(e)) + ")" });
+      }
+    });
+  }
+
   function pluginNames() {
     return safe(function () {
       var names = [];
@@ -259,7 +337,35 @@
     container.insertBefore(banner, container.firstChild);
   }
 
-  function render(audio) {
+  // Build the "workers" table from the dedicated worker's posted signals. Each navigator/timezone row
+  // compares against the SAME common profile the window rows use, so green here means worker == window
+  // (both uniformized). Canvas readback is pass/fail on whether the worker's OffscreenCanvas came back
+  // transparent; the WebGL unmasked strings compare to the common GPU identity. When the worker could
+  // not run, a single info row explains why (no false failure).
+  function workersTable(worker) {
+    if (!worker || worker.unavailable) {
+      return buildTable("workers (dedicated)", [
+        ["worker status", worker && worker.unavailable ? worker.unavailable : "no result", null],
+      ]);
+    }
+    var canvasOk = worker.canvasNeutralized === true ? true : worker.canvasNeutralized === false ? false : null;
+    var hasWebgl = typeof worker.webglUnmaskedRenderer === "string" && worker.webglUnmaskedRenderer.length > 0;
+    return buildTable("workers (dedicated)", [
+      ["navigator.userAgent", worker.userAgent, is(worker.userAgent, EXPECTED.ua)],
+      ["navigator.appVersion", worker.appVersion, is(worker.appVersion, EXPECTED.appVersion)],
+      ["navigator.platform", worker.platform, is(worker.platform, EXPECTED.platform)],
+      ["navigator.language", worker.language, is(worker.language, EXPECTED.language)],
+      ["navigator.languages", worker.languages, is(worker.languages, EXPECTED.languages)],
+      ["navigator.hardwareConcurrency", worker.hardwareConcurrency, is(worker.hardwareConcurrency, EXPECTED.hardwareConcurrency)],
+      ["Intl timeZone", worker.timezone, is(worker.timezone, EXPECTED.timezone)],
+      ["getTimezoneOffset (minutes)", worker.offset, is(worker.offset, EXPECTED.offset)],
+      ["OffscreenCanvas readback", canvasOk === true ? "transparent (neutralized)" : canvasOk === false ? "leaking real pixels" : "no OffscreenCanvas", canvasOk],
+      ["WebGL unmasked vendor", hasWebgl ? worker.webglUnmaskedVendor : "(not exposed)", hasWebgl ? is(worker.webglUnmaskedVendor, EXPECTED.webglUnmaskedVendor) : null],
+      ["WebGL unmasked renderer", hasWebgl ? worker.webglUnmaskedRenderer : "(not exposed)", hasWebgl ? is(worker.webglUnmaskedRenderer, EXPECTED.webglUnmaskedRenderer) : null],
+    ]);
+  }
+
+  function render(audio, worker) {
     var gl = webgl();
     var canvas = canvasProbe();
     var canvasOk = canvas && typeof canvas === "object" ? canvas.ok : null;
@@ -323,9 +429,14 @@
 
     container.appendChild(buildTable("Web Audio", [["readback hash", audio.text, audio.ok]]));
 
+    // Worker parity (issue #38): the same signals read from inside a dedicated worker.
+    container.appendChild(workersTable(worker));
+
     // Probe CSP last so the earlier tables are not disturbed, then print the verdict at the top.
     renderConclusion(container, inlineScriptsBlocked());
   }
 
-  audioProbe().then(render);
+  Promise.all([audioProbe(), workerProbe()]).then(function (results) {
+    render(results[0], results[1]);
+  });
 })();

--- a/testpage/fingerprint.html
+++ b/testpage/fingerprint.html
@@ -106,8 +106,9 @@
       Signals in scope: navigator (userAgent, appVersion, platform, language, languages,
       hardwareConcurrency, oscpu), screen (width, height, availWidth, availHeight, colorDepth,
       pixelDepth, devicePixelRatio), timezone (Intl zone and getTimezoneOffset), canvas readback,
-      WebGL vendor and renderer, navigator plugins and mimeTypes, and Web Audio readback. Font
-      metrics are intentionally not modified in this version.
+      WebGL vendor and renderer, navigator plugins and mimeTypes, Web Audio readback, and the same
+      navigator, canvas and WebGL signals re-read from inside a dedicated Web Worker (worker == window
+      parity). Font metrics are intentionally not modified in this version.
     </footer>
     <script src="fingerprint-test.js"></script>
   </body>


### PR DESCRIPTION
Closes #38. Part of #34 (v1 → v2).

## Problem
Web/Shared/Service Workers expose their own `WorkerNavigator` and `OffscreenCanvas` with the real device values. The overrides so far were window-only, so any script reading `navigator` or doing canvas/WebGL readback from inside a worker leaked the real, unspoofed values — the window-vs-worker mismatch CreepJS specifically flags, and the single biggest remaining detector gap.

## What changed
- **`src/fingerprint/workers.ts` (new, MAIN world):** wraps the `Worker` and `SharedWorker` constructors and prepends a self-contained override bootstrap to the worker source (via a blob URL), then `importScripts()`/`import()`s the site's original script. The bootstrap applies the same OS-resolved common profile the window uses:
  - `WorkerNavigator`: userAgent, appVersion, platform, language, languages, hardwareConcurrency
  - timezone: `Intl.DateTimeFormat().resolvedOptions().timeZone` and `Date.getTimezoneOffset()`
  - OffscreenCanvas readback: `convertToBlob` and the 2D `getImageData`
  - WebGL vendor/renderer masking (`Mozilla` masked, common ANGLE identity unmasked)

  The override body is serialized with `toString()` and re-parsed in the worker realm, so it deliberately relies only on its argument and worker globals.
- **`src/fingerprint/inject.ts`:** also neutralize `OffscreenCanvas` readback on the **main thread** (`convertToBlob`, 2D `getImageData`), which previously bypassed the `HTMLCanvasElement` patch.
- **`background.ts` / `build.mjs`:** bundle and register `fingerprint-workers.js` before any site script, so the constructors are wrapped before a page can spawn a worker.
- **testpage:** a dedicated worker re-reads navigator, canvas and WebGL from inside a worker realm and compares each signal to the common profile, so `worker == window` parity is visible.

## Acceptance criteria
- [x] `navigator` + canvas readback uniformized in **dedicated** and **shared** workers
- [x] OffscreenCanvas readback uniformized (window and worker)
- [ ] **Service workers** — see limitations
- [x] Worker signals match the window (verifiable on the test page and CreepJS)

## Known limitations
- **Service workers are not covered.** A service worker script URL must be a same-origin `http(s)` resource; the browser rejects a blob/data bootstrap, so there is no content-script-reachable injection path. Covering them needs a background `webRequest` response rewrite (identifying worker scripts via `Sec-Fetch-Dest`), which is a separate, heavier change — deferred as follow-up.
- **Strict CSP:** a page whose CSP forbids blob/worker sources (e.g. `worker-src 'self'`) will reject the blob-URL worker. We fail open on anything catchable synchronously, but an async CSP block can leave the site's worker not running. This is the documented blob/CSP tradeoff of worker injection.
- **Nested workers** (a worker spawning a sub-worker) are not re-wrapped, so a sub-worker is uncovered.

## Test
- `npm run build` (typecheck + esbuild) — clean.
- `npx web-ext lint` — 0 errors.
- Manual: open `testpage/fingerprint.html` with the extension enabled — the new "workers (dedicated)" table shows the common profile (green) instead of the real device values.